### PR TITLE
use old thread stealer and benchmark perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7431,7 +7431,6 @@ dependencies = [
  "polkadot-service",
  "pretty_env_logger",
  "primitive-types",
- "rayon",
  "refinery",
  "sc-chain-spec",
  "sc-client-api",
@@ -7452,6 +7451,7 @@ dependencies = [
  "sqlx",
  "tempfile",
  "thiserror",
+ "threadpool",
 ]
 
 [[package]]

--- a/archive/Cargo.toml
+++ b/archive/Cargo.toml
@@ -28,8 +28,8 @@ crossbeam = "0.7"
 parking_lot = "0.10"
 hashbrown = "0.8.0"
 thiserror = "1.0.20"
-rayon = "1.3.1"
 num_cpus = "1"
+threadpool = "1.8"
 # Sql migrations
 refinery = { version = "0.3.0", features = ["postgres"] }
 

--- a/archive/src/actors.rs
+++ b/archive/src/actors.rs
@@ -132,9 +132,8 @@ where
             ApiAccess<NotSignedBlock<T>, ReadOnlyBackend<NotSignedBlock<T>>, Runtime> + 'static,
     {
         let mut workers = std::collections::HashMap::new();
-        let broker =
-            ThreadedBlockExecutor::new(block_workers, client_api.clone(), backend.clone())?;
-
+        let broker = ThreadedBlockExecutor::new(block_workers, client_api.clone(), backend.clone());
+        let broker = BlockBroker::from_executor(broker)?;
         Bastion::init();
         let pool = run!(PgPool::builder().max_size(8).build(psql_url))?;
 

--- a/archive/src/error.rs
+++ b/archive/src/error.rs
@@ -39,9 +39,8 @@ pub enum Error {
     Dns(#[from] jsonrpsee::transport::ws::WsNewDnsError),
     #[error("couldn't run migrations")]
     SqlMigration(#[from] refinery::Error),
-    #[error("could not build threadpool")]
-    ThreadPool(#[from] rayon::ThreadPoolBuildError),
-
+    // #[error("could not build threadpool")]
+    // ThreadPool(#[from] rayon::ThreadPoolBuildError),
     #[error("sending on disconnected channel")]
     Channel,
     #[error("Unexpected Error {0}")]


### PR DESCRIPTION
using rayon seems to have regressed performance

Both rayon and this threadpool use crossbeam::deque in order to schedule tasks between threads. However, rayon stores tasks as closures on the heap, and tasks with this threadpool are just queued blocks to execute. Rayon also seemed to use lots of memory comparatively (however, the memory issue could probably have been fixed with some further tweaking).