### PR TITLE
Actor Decoupling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
 dependencies = [
- "gimli 0.22.0",
+ "gimli",
 ]
 
 [[package]]
@@ -312,7 +312,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.20.0",
+ "object",
  "rustc-demangle",
 ]
 
@@ -751,98 +751,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d375c433320f6c5057ae04a04376eef4d04ce2801448cf8863a78da99107be4"
 
 [[package]]
-name = "cranelift-bforest"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4425bb6c3f3d2f581c650f1a1fdd3196a975490149cf59bea9d34c3bea79eda"
-dependencies = [
- "cranelift-entity",
-]
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d166b289fd30062ee6de86284750fc3fe5d037c6b864b3326ce153239b0626e1"
-dependencies = [
- "byteorder",
- "cranelift-bforest",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-entity",
- "gimli 0.20.0",
- "log 0.4.8",
- "regalloc",
- "serde",
- "smallvec 1.4.1",
- "target-lexicon",
- "thiserror",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c9fb2306a36d41c5facd4bf3400bc6c157185c43a96eaaa503471c34c5144b"
-dependencies = [
- "cranelift-codegen-shared",
- "cranelift-entity",
-]
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e0cfe9b1f97d9f836bca551618106c7d53b93b579029ecd38e73daa7eb689e"
-
-[[package]]
-name = "cranelift-entity"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926a73c432e5ba9c891171ff50b75e7d992cd76cd271f0a0a0ba199138077472"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cranelift-frontend"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45f82e3446dd1ebb8c2c2f6a6b0e6cd6cd52965c7e5f7b1b35e9a9ace31ccde"
-dependencies = [
- "cranelift-codegen",
- "log 0.4.8",
- "smallvec 1.4.1",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-native"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488b5d481bb0996a143e55a9d1739ef425efa20d4a5e5e98c859a8573c9ead9a"
-dependencies = [
- "cranelift-codegen",
- "raw-cpuid",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-wasm"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00aa8dde71fd9fdb1958e7b0ef8f524c1560e2c6165e4ea54bc302b40551c161"
-dependencies = [
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-frontend",
- "log 0.4.8",
- "serde",
- "thiserror",
- "wasmparser 0.51.4",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,48 +1056,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b480f641ccf0faf324e20c1d3e53d81b7484c698b42ea677f6907ae4db195371"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
-dependencies = [
- "gcc",
- "libc",
-]
-
-[[package]]
 name = "exit-future"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
  "futures 0.3.5",
-]
-
-[[package]]
-name = "faerie"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfef65b0e94693295c5d2fe2506f0ee6f43465342d4b5331659936aee8b16084"
-dependencies = [
- "goblin",
- "indexmap",
- "log 0.4.8",
- "scroll",
- "string-interner",
- "target-lexicon",
- "thiserror",
 ]
 
 [[package]]
@@ -1239,16 +1111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9a4820f0ccc8a7afd67c39a0f1a0f4b07ca1725164271a64939d7aeb9af065"
 dependencies = [
  "colored",
- "log 0.4.8",
-]
-
-[[package]]
-name = "file-per-thread-logger"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3937f028664bd0e13df401ba49a4567ccda587420365823242977f06609ed1"
-dependencies = [
- "env_logger",
  "log 0.4.8",
 ]
 
@@ -1775,20 +1637,6 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dd6190aad0f05ddbbf3245c54ed14ca4aa6dd32f22312b70d8f168c3e3e633"
-dependencies = [
- "arrayvec 0.5.1",
- "byteorder",
- "fallible-iterator",
- "indexmap",
- "smallvec 1.4.1",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "gimli"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
@@ -1823,17 +1671,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "goblin"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3081214398d39e4bd7f2c1975f0488ed04614ffdd976c6fc7a0708278552c0da"
-dependencies = [
- "log 0.4.8",
- "plain",
- "scroll",
 ]
 
 [[package]]
@@ -2591,12 +2428,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
-name = "leb128"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
-
-[[package]]
 name = "libc"
 version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3049,15 +2880,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3248,12 +3070,6 @@ dependencies = [
  "socket2",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "more-asserts"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "multihash"
@@ -3465,15 +3281,6 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5666bbb90bc4d1e5bdcb26c0afda1822d25928341e9384ab187a9b37ab69e36"
-dependencies = [
- "target-lexicon",
 ]
 
 [[package]]
@@ -4423,12 +4230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "polkadot-archive"
 version = "0.2.1"
 dependencies = [
@@ -5255,17 +5056,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "raw-cpuid"
-version = "7.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a349ca83373cfa5d6dbb66fd76e58b2cca08da71a5f6400de0a0a6a9bceeaf"
-dependencies = [
- "bitflags",
- "cc",
- "rustc_version",
-]
-
-[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5395,17 +5185,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regalloc"
-version = "0.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27b256b41986ac5141b37b8bbba85d314fbf546c182eb255af6720e07e4f804"
-dependencies = [
- "log 0.4.8",
- "rustc-hash",
- "smallvec 1.4.1",
-]
-
-[[package]]
 name = "regex"
 version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5422,18 +5201,6 @@ name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
-
-[[package]]
-name = "region"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
-dependencies = [
- "bitflags",
- "libc",
- "mach",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "remove_dir_all"
@@ -5915,7 +5682,6 @@ dependencies = [
  "parking_lot 0.10.2",
  "sc-executor-common",
  "sc-executor-wasmi",
- "sc-executor-wasmtime",
  "sp-api",
  "sp-core",
  "sp-externalities",
@@ -5959,27 +5725,6 @@ dependencies = [
  "sp-runtime-interface",
  "sp-wasm-interface",
  "wasmi",
-]
-
-[[package]]
-name = "sc-executor-wasmtime"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate#4c4e6da577e7281bb70ca9e72dc1a58663c36164"
-dependencies = [
- "cranelift-codegen",
- "cranelift-wasm",
- "log 0.4.8",
- "parity-scale-codec",
- "parity-wasm",
- "sc-executor-common",
- "scoped-tls 1.0.0",
- "sp-allocator",
- "sp-core",
- "sp-runtime-interface",
- "sp-wasm-interface",
- "substrate-wasmtime",
- "substrate-wasmtime-runtime",
- "wasmtime-environ",
 ]
 
 [[package]]
@@ -6484,26 +6229,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scroll"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb2332cb595d33f7edd5700f4cbf94892e680c7f0ae56adab58a35190b66cb1"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e367622f934864ffa1c704ba2b82280aab856e3d8213c84c5720257eb34b15b9"
-dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "syn 1.0.33",
-]
 
 [[package]]
 name = "sct"
@@ -7580,15 +7305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "string-interner"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd710eadff449a1531351b0e43eb81ea404336fa2f56c777427ab0e32a4cf183"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7738,95 +7454,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2a965994514ab35d3893e9260245f2947fd1981cdd4fffd2c6e6d1a9ce02e6a"
 
 [[package]]
-name = "substrate-wasmtime"
-version = "0.16.0-threadsafe.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd62264edc1a5f3ef44d86fb0c11c9fb142894b9a2da034f34afae482080d7a"
-dependencies = [
- "anyhow",
- "backtrace",
- "cfg-if",
- "lazy_static",
- "libc",
- "region",
- "rustc-demangle",
- "substrate-wasmtime-jit",
- "substrate-wasmtime-profiling",
- "substrate-wasmtime-runtime",
- "target-lexicon",
- "wasmparser 0.52.2",
- "wasmtime-environ",
- "wat",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "substrate-wasmtime-jit"
-version = "0.16.0-threadsafe.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce43c159d4f3ef6b19641e1ae045847fd202d8e2cc74df7ccb2b6475e069d4a"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
- "cranelift-wasm",
- "gimli 0.20.0",
- "log 0.4.8",
- "more-asserts",
- "region",
- "substrate-wasmtime-profiling",
- "substrate-wasmtime-runtime",
- "target-lexicon",
- "thiserror",
- "wasmparser 0.52.2",
- "wasmtime-debug",
- "wasmtime-environ",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "substrate-wasmtime-profiling"
-version = "0.16.0-threadsafe.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77f0ce539b5a09a54dc80a1cf0c7cd7e694df11029354fe50a2d5fe889bdb97"
-dependencies = [
- "anyhow",
- "cfg-if",
- "gimli 0.20.0",
- "lazy_static",
- "libc",
- "object 0.18.0",
- "scroll",
- "serde",
- "substrate-wasmtime-runtime",
- "target-lexicon",
- "wasmtime-environ",
-]
-
-[[package]]
-name = "substrate-wasmtime-runtime"
-version = "0.16.0-threadsafe.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46516af0a64a7d9b652c5aa7436b6ce13edfa54435a66ef177fc02d2283e2dc2"
-dependencies = [
- "backtrace",
- "cc",
- "cfg-if",
- "indexmap",
- "lazy_static",
- "libc",
- "memoffset",
- "more-asserts",
- "region",
- "thiserror",
- "wasmtime-environ",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7912,12 +7539,6 @@ name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
-
-[[package]]
-name = "target-lexicon"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0e7238dcc7b40a7be719a25365910f6807bd864f4cce6b2e6b873658e2b19d"
 
 [[package]]
 name = "tempfile"
@@ -8763,81 +8384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.51.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
-
-[[package]]
-name = "wasmparser"
-version = "0.52.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733954023c0b39602439e60a65126fd31b003196d3a1e8e4531b055165a79b31"
-
-[[package]]
-name = "wasmtime-debug"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39ba645aee700b29ff0093028b4123556dd142a74973f04ed6225eedb40e77d"
-dependencies = [
- "anyhow",
- "faerie",
- "gimli 0.20.0",
- "more-asserts",
- "target-lexicon",
- "thiserror",
- "wasmparser 0.51.4",
- "wasmtime-environ",
-]
-
-[[package]]
-name = "wasmtime-environ"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed54fd9d64dfeeee7c285fd126174a6b5e6d4efc7e5a1566fdb635e60ff6a74e"
-dependencies = [
- "anyhow",
- "base64 0.12.3",
- "bincode",
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-wasm",
- "directories",
- "errno",
- "file-per-thread-logger",
- "indexmap",
- "libc",
- "log 0.4.8",
- "more-asserts",
- "rayon",
- "serde",
- "sha2 0.8.2",
- "thiserror",
- "toml",
- "wasmparser 0.51.4",
- "winapi 0.3.9",
- "zstd",
-]
-
-[[package]]
-name = "wast"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1844f66a2bc8526d71690104c0e78a8e59ffa1597b7245769d174ebb91deb5"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wat"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce85d72b74242c340e9e3492cfb602652d7bb324c3172dd441b5577e39a2e18c"
-dependencies = [
- "wast",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9100,35 +8646,4 @@ dependencies = [
  "quote 1.0.7",
  "syn 1.0.33",
  "synstructure",
-]
-
-[[package]]
-name = "zstd"
-version = "0.5.3+zstd.1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b32eaf771efa709e8308605bbf9319bf485dc1503179ec0469b611937c0cd8"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "2.0.5+zstd.1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfb642e0d27f64729a639c52db457e0ae906e7bc6f5fe8f5c453230400f1055"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "1.4.17+zstd.1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89249644df056b522696b1bb9e7c18c87e8ffa3e2f0dc3b0155875d6498f01b"
-dependencies = [
- "cc",
- "glob",
- "itertools 0.9.0",
- "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,8 +2303,8 @@ dependencies = [
 
 [[package]]
 name = "kusama-runtime"
-version = "0.8.14"
-source = "git+https://github.com/paritytech/polkadot#8845df228f6db595a76885e2ee25e58a598c9233"
+version = "0.8.15"
+source = "git+https://github.com/paritytech/polkadot#228010ea0302fcfba1ec7799511f85ca11f20e5f"
 dependencies = [
  "bitvec",
  "frame-executive",
@@ -4249,8 +4249,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-store"
-version = "0.8.14"
-source = "git+https://github.com/paritytech/polkadot#8845df228f6db595a76885e2ee25e58a598c9233"
+version = "0.8.15"
+source = "git+https://github.com/paritytech/polkadot#228010ea0302fcfba1ec7799511f85ca11f20e5f"
 dependencies = [
  "derive_more 0.99.9",
  "exit-future",
@@ -4277,7 +4277,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.7.30"
-source = "git+https://github.com/paritytech/polkadot#8845df228f6db595a76885e2ee25e58a598c9233"
+source = "git+https://github.com/paritytech/polkadot#228010ea0302fcfba1ec7799511f85ca11f20e5f"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -4287,8 +4287,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "0.8.14"
-source = "git+https://github.com/paritytech/polkadot#8845df228f6db595a76885e2ee25e58a598c9233"
+version = "0.8.15"
+source = "git+https://github.com/paritytech/polkadot#228010ea0302fcfba1ec7799511f85ca11f20e5f"
 dependencies = [
  "derive_more 0.15.0",
  "parity-scale-codec",
@@ -4300,8 +4300,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-network"
-version = "0.8.14"
-source = "git+https://github.com/paritytech/polkadot#8845df228f6db595a76885e2ee25e58a598c9233"
+version = "0.8.15"
+source = "git+https://github.com/paritytech/polkadot#228010ea0302fcfba1ec7799511f85ca11f20e5f"
 dependencies = [
  "arrayvec 0.4.12",
  "bytes 0.5.5",
@@ -4328,8 +4328,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain"
-version = "0.8.14"
-source = "git+https://github.com/paritytech/polkadot#8845df228f6db595a76885e2ee25e58a598c9233"
+version = "0.8.15"
+source = "git+https://github.com/paritytech/polkadot#228010ea0302fcfba1ec7799511f85ca11f20e5f"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.8",
@@ -4348,8 +4348,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-primitives"
-version = "0.8.14"
-source = "git+https://github.com/paritytech/polkadot#8845df228f6db595a76885e2ee25e58a598c9233"
+version = "0.8.15"
+source = "git+https://github.com/paritytech/polkadot#228010ea0302fcfba1ec7799511f85ca11f20e5f"
 dependencies = [
  "bitvec",
  "frame-system",
@@ -4370,8 +4370,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-rpc"
-version = "0.8.14"
-source = "git+https://github.com/paritytech/polkadot#8845df228f6db595a76885e2ee25e58a598c9233"
+version = "0.8.15"
+source = "git+https://github.com/paritytech/polkadot#228010ea0302fcfba1ec7799511f85ca11f20e5f"
 dependencies = [
  "jsonrpc-core",
  "pallet-transaction-payment-rpc",
@@ -4397,8 +4397,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime"
-version = "0.8.14"
-source = "git+https://github.com/paritytech/polkadot#8845df228f6db595a76885e2ee25e58a598c9233"
+version = "0.8.15"
+source = "git+https://github.com/paritytech/polkadot#228010ea0302fcfba1ec7799511f85ca11f20e5f"
 dependencies = [
  "bitvec",
  "frame-executive",
@@ -4448,6 +4448,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-core",
  "sp-inherents",
+ "sp-io",
  "sp-offchain",
  "sp-runtime",
  "sp-session",
@@ -4461,8 +4462,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "0.8.14"
-source = "git+https://github.com/paritytech/polkadot#8845df228f6db595a76885e2ee25e58a598c9233"
+version = "0.8.15"
+source = "git+https://github.com/paritytech/polkadot#228010ea0302fcfba1ec7799511f85ca11f20e5f"
 dependencies = [
  "bitvec",
  "frame-support",
@@ -4494,8 +4495,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-service"
-version = "0.8.14"
-source = "git+https://github.com/paritytech/polkadot#8845df228f6db595a76885e2ee25e58a598c9233"
+version = "0.8.15"
+source = "git+https://github.com/paritytech/polkadot#228010ea0302fcfba1ec7799511f85ca11f20e5f"
 dependencies = [
  "frame-benchmarking",
  "frame-system-rpc-runtime-api",
@@ -4553,8 +4554,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-table"
-version = "0.8.14"
-source = "git+https://github.com/paritytech/polkadot#8845df228f6db595a76885e2ee25e58a598c9233"
+version = "0.8.15"
+source = "git+https://github.com/paritytech/polkadot#228010ea0302fcfba1ec7799511f85ca11f20e5f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -4563,8 +4564,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-validation"
-version = "0.8.14"
-source = "git+https://github.com/paritytech/polkadot#8845df228f6db595a76885e2ee25e58a598c9233"
+version = "0.8.15"
+source = "git+https://github.com/paritytech/polkadot#228010ea0302fcfba1ec7799511f85ca11f20e5f"
 dependencies = [
  "ansi_term 0.12.1",
  "bitvec",
@@ -8432,8 +8433,8 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "0.8.14"
-source = "git+https://github.com/paritytech/polkadot#8845df228f6db595a76885e2ee25e58a598c9233"
+version = "0.8.15"
+source = "git+https://github.com/paritytech/polkadot#228010ea0302fcfba1ec7799511f85ca11f20e5f"
 dependencies = [
  "bitvec",
  "frame-executive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fed639d60b58d0f53498ab13d26f621fd77569cc6edb031f4cc36a2ad9da0f"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6030,7 +6039,7 @@ version = "0.8.0-rc4"
 source = "git+https://github.com/paritytech/substrate#4c4e6da577e7281bb70ca9e72dc1a58663c36164"
 dependencies = [
  "derive_more 0.99.9",
- "directories",
+ "directories 2.0.2",
  "exit-future",
  "futures 0.1.29",
  "futures 0.3.5",
@@ -7350,7 +7359,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "chrono",
- "directories",
+ "directories 3.0.1",
  "fern",
  "flate2",
  "flume",

--- a/archive/Cargo.toml
+++ b/archive/Cargo.toml
@@ -60,7 +60,7 @@ sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", 
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", package = "sp-api" }
 sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master", package = "sp-block-builder" }
 sp-version = {  git = "https://github.com/paritytech/substrate", branch = "master", package = "sp-version" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master", package = "sc-executor", features = ["wasmtime"] }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master", package = "sc-executor" }
 sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "master", package = "sc-chain-spec" }
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master", package = "sp-trie" } 
 sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master", package = "sp-state-machine" }

--- a/archive/Cargo.toml
+++ b/archive/Cargo.toml
@@ -46,7 +46,7 @@ jsonrpsee = { git = "https://github.com/dt665m/jsonrpsee", branch = "feature/cli
 kvdb = "0.7"
 kvdb-rocksdb = "0.9"
 parity-util-mem = { version = "*", default-features = false, features = ["std"] }
-codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive", "full"] }
+codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive", "full"] }
 hash-db = "0.15"
 
 # Substrate

--- a/archive/Cargo.toml
+++ b/archive/Cargo.toml
@@ -15,7 +15,7 @@ timer = { version = "3.0", package = "futures-timer" }
 serde = { version = "1.0", features = ["derive"] }
 # enabling arbitrary_precision for serde_json may cause rpc requests to fail
 serde_json = "1.0"
-dirs = { version = "2", package = "directories" }
+dirs = { version = "3", package = "directories" }
 sqlx = { git = "https://github.com/launchbadge/sqlx", branch = "master", version = "0.4.0-pre", default-features = false, features = ["postgres", "macros", "runtime-tokio"] }
 # sqlx = { version = "0.3", features = ["postgres", "tls", "macros"] }
 async-trait = "0.1"
@@ -72,8 +72,8 @@ polkadot-service = { package = "polkadot-service", git = "https://github.com/par
 
 pretty_env_logger = "0.4.0"
 # used in tests for storing test data on disk
-flate2 = "1.0.14"
-bincode = "1.2.1"
+flate2 = "1.0"
+bincode = "1.3"
 tempfile = "3.1"
 
 [features]

--- a/archive/src/actors.rs
+++ b/archive/src/actors.rs
@@ -145,8 +145,8 @@ where
     /// Start the actors and begin driving their execution
     pub async fn drive(&mut self) -> ArchiveResult<()> {
         let pool = PgPool::builder()
-            .min_size(8)
-            .max_size(16)
+            .min_size(4)
+            .max_size(8)
             .build(self.context.psql_url())
             .await?;
         let ctx = self.context.clone();
@@ -154,7 +154,6 @@ where
         let tx = self.executor.sender();
         let rpc = crate::rpc::Rpc::<B>::connect(ctx.rpc_url()).await?;
         let subscription = rpc.subscribe_finalized_heads().await?;
-        log::info!("Blocking on filling storage");
         let (conn0, conn1) = (pool.acquire().await?, pool.acquire().await?);
         crate::util::spawn(fill_storage(conn0, tx.clone()));
         let ag = Aggregator::new(ctx.clone(), tx, pool).await?.spawn();

--- a/archive/src/actors/actor_ext.rs
+++ b/archive/src/actors/actor_ext.rs
@@ -1,0 +1,82 @@
+// Copyright 2017-2019 Parity Technologies (UK) Ltd.
+// This file is part of substrate-archive.
+
+// substrate-archive is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// substrate-archive is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with substrate-archive.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::error::Error;
+use xtra::prelude::*;
+use xtra::{Disconnected, MessageResponseFuture};
+
+/// A system in which actors run
+struct System {
+    name: String,
+}
+
+impl System {
+    pub fn new<T: Into<String>>(name: T) -> Self {
+
+        Self {
+            name: name.into()
+        }
+    }
+
+    pub fn register_error_handler(handler: impl Fn(&dyn Error)) {
+        unimplemented!()
+    }
+
+    /// Stop the system
+    pub fn stop(&self) {
+        unimplemented!()
+    }
+}
+
+/// Trait that marks this struct as it's failures being able to be handled by a Supervisor
+pub trait MinionHandler<T, Err, M: Message<Result = Result<T, Err>>>: Actor + Handler<M> 
+where
+    T: Send,
+    Err: Error + Send
+{
+}
+
+impl<O, Err, M, T> MinionHandler<O, Err, M> for T 
+where
+    O: Send,
+    Err: Error + Send,
+    M: Message<Result = Result<O, Err>>,
+    T: Handler<M> + Send
+{
+}
+
+
+pub trait MinionAddressExt<A: Actor> {
+
+    fn handled_do_send<T, E, M>(&self, message: M) -> Result<(), Disconnected>
+    where
+        M: Message<Result = Result<T, E>>,
+        T: Send,
+        E: Error + Send,
+        A: MinionHandler<T, E, M> + Send;
+}
+
+impl<A: Actor> MinionAddressExt<A> for Address<A> {
+    
+    fn handled_do_send<T, E, M>(&self, message: M) -> Result<(), Disconnected>
+    where
+        M: Message<Result = Result<T, E>>,
+        T: Send,
+        E: Error + Send,
+        A: MinionHandler<T, E, M> + Send {
+            Ok(())
+        }
+}

--- a/archive/src/actors/actor_pool.rs
+++ b/archive/src/actors/actor_pool.rs
@@ -115,6 +115,7 @@ where
 }
 
 impl<A: Actor> Actor for ActorPool<A> {}
+
 // We need a concrete struct for this otherwise our handler implementation
 // conflicts with xtra's generic implementation for all T
 pub struct PoolMessage<M: Message + Send>(pub M);

--- a/archive/src/actors/actor_pool.rs
+++ b/archive/src/actors/actor_pool.rs
@@ -24,6 +24,10 @@ use std::pin::Pin;
 use xtra::prelude::*;
 use xtra::{Disconnected, WeakAddress};
 
+// TODO: Could restart actors which have panicked
+
+/// A pool of one type of Actor
+/// will distribute work to all actors in the pool
 pub struct ActorPool<A: Actor> {
     queue: VecDeque<Address<A>>,
     pure_actor: A,

--- a/archive/src/actors/generators.rs
+++ b/archive/src/actors/generators.rs
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-archive.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::{actor_pool::ActorPool, workers::GetState};
+use super::{actor_pool::ActorPool, workers::{GetState, DatabaseActor}};
 use crate::{
-    database::Database, error::ArchiveResult, queries, sql_block_builder::BlockBuilder,
+    error::ArchiveResult, queries, sql_block_builder::BlockBuilder,
     threadpools::BlockData,
 };
 use flume::Sender;
@@ -27,7 +27,7 @@ use xtra::prelude::*;
 
 pub struct Generator<B: BlockT> {
     last_block_max: u32,
-    addr: Address<ActorPool<Database>>,
+    addr: Address<ActorPool<DatabaseActor<B>>>,
     tx_block: Sender<BlockData<B>>,
     tx_num: Sender<u32>,
 }
@@ -36,7 +36,7 @@ type Conn = PoolConnection<Postgres>;
 
 impl<B: BlockT> Generator<B> {
     pub fn new(
-        actor_pool: Address<ActorPool<Database>>,
+        actor_pool: Address<ActorPool<DatabaseActor<B>>>,
         tx_block: Sender<BlockData<B>>,
         tx_num: Sender<u32>,
     ) -> Arc<Self> {

--- a/archive/src/actors/workers.rs
+++ b/archive/src/actors/workers.rs
@@ -19,12 +19,11 @@ mod database;
 mod metadata;
 
 pub use self::aggregator::Aggregator;
+pub use self::database::GetState;
 pub use self::metadata::Metadata;
 
-use super::{
-    actor_pool::{ActorPool, PoolMessage},
-    connect, ActorContext,
-};
+pub use super::generators::Generator;
+use super::{actor_pool::ActorPool, connect, ActorContext};
 pub use crate::database::Database;
 
 /// any messages defined in the workers

--- a/archive/src/actors/workers.rs
+++ b/archive/src/actors/workers.rs
@@ -21,7 +21,10 @@ mod metadata;
 pub use self::aggregator::Aggregator;
 pub use self::metadata::Metadata;
 
-use super::{actor_pool::ActorPool, connect, ActorContext};
+use super::{
+    actor_pool::{ActorPool, PoolConnection, PoolMessage},
+    connect, ActorContext,
+};
 pub use crate::database::Database;
 
 /// any messages defined in the workers

--- a/archive/src/actors/workers.rs
+++ b/archive/src/actors/workers.rs
@@ -22,7 +22,7 @@ pub use self::aggregator::Aggregator;
 pub use self::metadata::Metadata;
 
 use super::{
-    actor_pool::{ActorPool, PoolConnection, PoolMessage},
+    actor_pool::{ActorPool, PoolMessage},
     connect, ActorContext,
 };
 pub use crate::database::Database;

--- a/archive/src/actors/workers.rs
+++ b/archive/src/actors/workers.rs
@@ -24,7 +24,7 @@ pub use self::metadata::Metadata;
 
 pub use super::generators::Generator;
 use super::{actor_pool::ActorPool, connect, ActorContext};
-pub use crate::database::Database;
+pub use database::DatabaseActor;
 
 /// any messages defined in the workers
 pub mod msg {

--- a/archive/src/actors/workers/aggregator.rs
+++ b/archive/src/actors/workers/aggregator.rs
@@ -127,8 +127,8 @@ where
     ) -> ArchiveResult<Self> {
         let (psql_url, rpc_url) = (ctx.psql_url().to_string(), ctx.rpc_url().to_string());
         let db = super::Database::with_pool(psql_url, pool);
-        let db_pool = super::ActorPool::new(db, 4).spawn();
-        let meta = super::Metadata::new(rpc_url, db_pool.clone())
+        let db_pool = super::ActorPool::new(db.clone(), 4).spawn();
+        let meta_addr = super::Metadata::new(rpc_url, db_pool.clone())
             .await?
             .spawn();
         let (senders, recvs) = queues();
@@ -137,7 +137,7 @@ where
             senders,
             db_pool,
             recvs: Some(recvs),
-            meta_addr: meta,
+            meta_addr,
             exec: tx,
             last_count_was_0: false,
         })

--- a/archive/src/actors/workers/aggregator.rs
+++ b/archive/src/actors/workers/aggregator.rs
@@ -44,7 +44,7 @@ where
     senders: Senders<B>,
     recvs: Option<Receivers<B>>,
     /// actor which inserts blocks into the database
-    db_pool: Address<super::ActorPool<super::Database>>,
+    db_pool: Address<super::ActorPool<super::DatabaseActor<B>>>,
     /// Actor which manages getting the runtime metadata for blocks
     /// and sending them to the database actor
     meta_addr: Address<super::Metadata<B>>,
@@ -126,8 +126,8 @@ where
         tx_num: Sender<u32>,
     ) -> ArchiveResult<Self> {
         let (psql_url, rpc_url) = (ctx.psql_url().to_string(), ctx.rpc_url().to_string());
-        let db = super::Database::new(psql_url).await?;
-        let db_pool = super::ActorPool::new(db.clone(), 4).spawn();
+        let db = super::DatabaseActor::new(psql_url).await?;
+        let db_pool = super::ActorPool::new(db, 4).spawn();
         let meta_addr = super::Metadata::new(rpc_url, db_pool.clone())
             .await?
             .spawn();

--- a/archive/src/actors/workers/aggregator.rs
+++ b/archive/src/actors/workers/aggregator.rs
@@ -122,15 +122,18 @@ where
 {
     pub async fn new(
         ctx: ActorContext<B>,
-        tx: Sender<BlockData<B>>,
-        pool: sqlx::PgPool,
+        tx_block: Sender<BlockData<B>>,
+        tx_num: Sender<u32>,
     ) -> ArchiveResult<Self> {
         let (psql_url, rpc_url) = (ctx.psql_url().to_string(), ctx.rpc_url().to_string());
-        let db = super::Database::with_pool(psql_url, pool);
+        let db = super::Database::new(psql_url).await?;
         let db_pool = super::ActorPool::new(db.clone(), 4).spawn();
         let meta_addr = super::Metadata::new(rpc_url, db_pool.clone())
             .await?
             .spawn();
+        super::Generator::new(db_pool.clone(), tx_block.clone(), tx_num)
+            .start()
+            .await?;
         let (senders, recvs) = queues();
 
         Ok(Self {
@@ -138,7 +141,7 @@ where
             db_pool,
             recvs: Some(recvs),
             meta_addr,
-            exec: tx,
+            exec: tx_block,
             last_count_was_0: false,
         })
     }
@@ -185,9 +188,14 @@ where
     B: BlockT,
     NumberFor<B>: Into<u32>,
 {
-    fn handle(&mut self, block: Block<B>, _: &mut Context<Self>) -> ArchiveResult<()> {
-        self.exec.send(BlockData::Single(block.clone()))?;
-        self.senders.push_back(BlockOrStorage::Block(block))
+    fn handle(&mut self, block: Block<B>, c: &mut Context<Self>) {
+        if let Err(_) = self.exec.send(BlockData::Single(block.clone())) {
+            c.stop();
+        }
+        let block = BlockOrStorage::Block(block);
+        if let Err(_) = self.senders.push_back(block) {
+            c.stop();
+        }
     }
 }
 
@@ -196,9 +204,14 @@ where
     B: BlockT,
     NumberFor<B>: Into<u32>,
 {
-    fn handle(&mut self, blocks: BatchBlock<B>, _: &mut Context<Self>) -> ArchiveResult<()> {
-        self.exec.send(BlockData::Batch(blocks.inner.clone()))?;
-        self.senders.push_back(BlockOrStorage::BatchBlock(blocks))
+    fn handle(&mut self, blocks: BatchBlock<B>, c: &mut Context<Self>) {
+        if let Err(_) = self.exec.send(BlockData::Batch(blocks.inner.clone())) {
+            c.stop();
+        }
+        let blocks = BlockOrStorage::BatchBlock(blocks);
+        if let Err(_) = self.senders.push_back(blocks) {
+            c.stop();
+        }
     }
 }
 

--- a/archive/src/actors/workers/aggregator.rs
+++ b/archive/src/actors/workers/aggregator.rs
@@ -250,14 +250,14 @@ where
             }
             (0, s) => {
                 self.db_pool
-                    .do_send(super::PoolMessage(storage))
+                    .do_send(storage.into())
                     .expect("Actor Disconnected");
                 log::info!("Indexing Storage {} bps", s);
                 self.last_count_was_0 = false;
             }
             (b, s) => {
                 self.db_pool
-                    .do_send(super::PoolMessage(storage))
+                    .do_send(storage.into())
                     .expect("Actor Disconnected");
                 self.meta_addr.do_send(blocks).expect("Actor Disconnected");
                 log::info!("Indexing Blocks {} bps, Indexing Storage {} bps", b, s);

--- a/archive/src/actors/workers/database.rs
+++ b/archive/src/actors/workers/database.rs
@@ -21,6 +21,11 @@ use crate::types::*;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
 use xtra::prelude::*;
 
+/// Get Some State from the Database Actor
+pub enum Get {
+    Conn,
+}
+
 impl Actor for Database {}
 
 #[async_trait::async_trait]

--- a/archive/src/actors/workers/database.rs
+++ b/archive/src/actors/workers/database.rs
@@ -61,7 +61,6 @@ where
             if db_contains_metadata(specs.as_slice(), versions) {
                 break;
             }
-            log::error!("Waiting....");
             timer::Delay::new(std::time::Duration::from_millis(50)).await;
         }
         std::mem::drop(conn);

--- a/archive/src/actors/workers/database.rs
+++ b/archive/src/actors/workers/database.rs
@@ -16,109 +16,88 @@
 
 use crate::database::{models::StorageModel, Database, DbConn};
 use crate::error::ArchiveResult;
-use crate::p_err;
 use crate::queries;
 use crate::types::*;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
+use std::marker::PhantomData;
 use xtra::prelude::*;
 
-impl Actor for Database {}
+#[derive(Clone)]
+pub struct DatabaseActor<B: BlockT> {
+    db: Database,
+    _marker: PhantomData<B>
+}
 
-#[async_trait::async_trait]
-impl<B> Handler<Block<B>> for Database
-where
-    B: BlockT,
-    NumberFor<B>: Into<u32>,
-{
-    async fn handle(&mut self, blk: Block<B>, _ctx: &mut Context<Self>) {
-        let mut conn = self.conn_unchecked().await;
-        while !p_err!(queries::check_if_meta_exists(blk.spec, &mut conn).await) {
+impl<B: BlockT> DatabaseActor<B> {
+    pub async fn new(url: String) -> ArchiveResult<Self> {
+        Ok(Self {
+            db: Database::new(url).await?,
+            _marker: PhantomData,
+        })
+    }
+
+    #[allow(unused)]
+    pub fn with_db(db: Database) -> Self {
+        Self {
+            db,
+            _marker: PhantomData
+        }     
+    }
+
+    async fn block_handler(&self, blk: Block<B>) -> ArchiveResult<()> 
+    where
+        NumberFor<B>: Into<u32>,
+    {
+        let mut conn = self.db.conn().await?;
+        while !queries::check_if_meta_exists(blk.spec, &mut conn).await? {
             timer::Delay::new(std::time::Duration::from_millis(20)).await;
         }
         std::mem::drop(conn);
-        self.insert_unchecked(blk).await;
+        self.db.insert(blk).await?;
+        Ok(())
     }
-}
 
-#[async_trait::async_trait]
-impl<B> Handler<BatchBlock<B>> for Database
-where
-    B: BlockT,
-    NumberFor<B>: Into<u32>,
-{
-    async fn handle(&mut self, mut blks: BatchBlock<B>, _ctx: &mut Context<Self>) {
+    async fn batch_block_handler(&self, mut blks: BatchBlock<B>) -> ArchiveResult<()> 
+    where
+        NumberFor<B>: Into<u32>,
+    {
         let specs = blks.mut_inner();
         specs.sort_by_key(|b| b.spec);
         let mut specs = specs.iter_mut().map(|b| b.spec).collect::<Vec<u32>>();
         specs.dedup();
-        let mut conn = self.conn_unchecked().await;
+        let mut conn = self.db.conn().await?;
         loop {
-            let versions = p_err!(queries::get_versions(&mut conn).await);
+            let versions = queries::get_versions(&mut conn).await?;
             if db_contains_metadata(specs.as_slice(), versions) {
                 break;
             }
             timer::Delay::new(std::time::Duration::from_millis(50)).await;
         }
         std::mem::drop(conn);
-        let now = std::time::Instant::now();
-        self.insert_unchecked(blks).await;
-        let elapsed = now.elapsed();
-        log::debug!(
-            "TOOK {} seconds, {} milli-seconds, {} micro-seconds, to insert blocks",
-            elapsed.as_secs(),
-            elapsed.as_millis(),
-            elapsed.as_micros(),
-        );
+        self.db.insert(blks).await?;
+        Ok(())
     }
-}
 
-#[async_trait::async_trait]
-impl Handler<Metadata> for Database {
-    async fn handle(&mut self, meta: Metadata, _ctx: &mut Context<Self>) {
-        self.insert_unchecked(meta).await;
-    }
-}
-
-#[async_trait::async_trait]
-impl<B: BlockT> Handler<Storage<B>> for Database {
-    async fn handle(&mut self, storage: Storage<B>, _ctx: &mut Context<Self>) {
-        let mut conn = self.conn_unchecked().await;
-        while !p_err!(queries::contains_block::<B>(*storage.hash(), &mut conn).await) {
+    async fn storage_handler(&self, storage: Storage<B>) -> ArchiveResult<()> {
+        let mut conn = self.db.conn().await?;
+        while !queries::contains_block::<B>(*storage.hash(), &mut conn).await? {
             timer::Delay::new(std::time::Duration::from_millis(10)).await;
         }
         let storage = Vec::<StorageModel<B>>::from(storage);
-        self.insert_unchecked(storage).await;
+        std::mem::drop(conn);
+        self.db.insert(storage).await?;
+        Ok(())
     }
-}
 
-pub struct VecStorageWrap<B: BlockT>(pub Vec<Storage<B>>);
-
-impl<B: BlockT> Message for VecStorageWrap<B> {
-    type Result = ArchiveResult<()>;
-}
-
-#[async_trait::async_trait]
-impl<B: BlockT> Handler<VecStorageWrap<B>> for Database {
-    async fn handle(
-        &mut self,
-        storage: VecStorageWrap<B>,
-        _ctx: &mut Context<Self>,
-    ) -> ArchiveResult<()> {
-        let mut conn = self.conn_unchecked().await;
-        let block_nums: Vec<u32> = storage.0.iter().map(|s| s.block_num()).collect();
-        while !p_err!(queries::contains_blocks::<B>(block_nums.as_slice(), &mut conn).await) {
+    async fn batch_storage_handler(&self, storage: Vec<Storage<B>>) -> ArchiveResult<()> {
+        let mut conn = self.db.conn().await?;
+        let block_nums: Vec<u32> = storage.iter().map(|s| s.block_num()).collect();
+        while !queries::contains_blocks::<B>(block_nums.as_slice(), &mut conn).await? {
             timer::Delay::new(std::time::Duration::from_millis(50)).await;
         }
-        let now = std::time::Instant::now();
-        let storage = Vec::<StorageModel<B>>::from(storage);
-        self.insert_unchecked(storage).await;
-        let elapsed = now.elapsed();
-        log::debug!(
-            "TOOK {} seconds, {} milli-seconds, {} micro-seconds, to insert storage",
-            elapsed.as_secs(),
-            elapsed.as_millis(),
-            elapsed.as_micros(),
-        );
+        let storage = Vec::<StorageModel<B>>::from(VecStorageWrap(storage));
+        std::mem::drop(conn);
+        self.db.insert(storage).await?;
         Ok(())
     }
 }
@@ -136,6 +115,74 @@ fn db_contains_metadata(specs: &[u32], versions: Vec<crate::queries::Version>) -
         }
     }
     true
+}
+
+impl<B: BlockT> Actor for DatabaseActor<B> {}
+
+#[async_trait::async_trait]
+impl<B> Handler<Block<B>> for DatabaseActor<B>
+where
+    B: BlockT,
+    NumberFor<B>: Into<u32>,
+{
+    async fn handle(&mut self, blk: Block<B>, _: &mut Context<Self>) {
+        if let Err(e) = self.block_handler(blk).await {
+            log::error!("{}", e.to_string())
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<B> Handler<BatchBlock<B>> for DatabaseActor<B>
+where
+    B: BlockT,
+    NumberFor<B>: Into<u32>,
+{
+    async fn handle(&mut self, blks: BatchBlock<B>, _: &mut Context<Self>) {
+        let now = std::time::Instant::now();
+        if let Err(e) = self.batch_block_handler(blks).await {
+            log::error!("{}", e.to_string());
+        }
+        log::debug!("TOOK {:?} to insert blocks", now.elapsed());
+    }
+}
+
+#[async_trait::async_trait]
+impl<B: BlockT> Handler<Metadata> for DatabaseActor<B> {
+    async fn handle(&mut self, meta: Metadata, _ctx: &mut Context<Self>) {
+        if let Err(e) = self.db.insert(meta).await {
+            log::error!("{}", e.to_string());
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<B: BlockT> Handler<Storage<B>> for DatabaseActor<B> {
+    async fn handle(&mut self, storage: Storage<B>, _ctx: &mut Context<Self>) {
+        if let Err(e) = self.storage_handler(storage).await {
+            log::error!("{}", e.to_string())
+        }
+    }
+}
+pub struct VecStorageWrap<B: BlockT>(pub Vec<Storage<B>>);
+
+impl<B: BlockT> Message for VecStorageWrap<B> {
+    type Result = ();
+}
+
+#[async_trait::async_trait]
+impl<B: BlockT> Handler<VecStorageWrap<B>> for DatabaseActor<B> {
+    async fn handle(
+        &mut self,
+        storage: VecStorageWrap<B>,
+        _ctx: &mut Context<Self>,
+    ) {
+        let now = std::time::Instant::now();
+        if let Err(e) = self.batch_storage_handler(storage.0).await {
+            log::error!("{}", e.to_string());
+        }
+        log::debug!("took {:?} to insert storage", now.elapsed());
+    }
 }
 
 // this is an enum in case there is some more state
@@ -169,7 +216,7 @@ impl Message for GetState {
 }
 
 #[async_trait::async_trait]
-impl Handler<GetState> for Database {
+impl<B: BlockT> Handler<GetState> for DatabaseActor<B> {
     async fn handle(
         &mut self,
         msg: GetState,
@@ -177,7 +224,7 @@ impl Handler<GetState> for Database {
     ) -> ArchiveResult<StateResponse> {
         match msg {
             GetState::Conn => {
-                let conn = self.conn().await?;
+                let conn = self.db.conn().await?;
                 Ok(StateResponse::Conn(conn))
             }
         }

--- a/archive/src/actors/workers/metadata.rs
+++ b/archive/src/actors/workers/metadata.rs
@@ -24,14 +24,10 @@ use crate::{
 use itertools::Itertools;
 use sp_runtime::traits::{Block as BlockT, Header as _, NumberFor};
 use xtra::prelude::*;
-use xtra::WeakAddress;
 
 /// Actor to fetch metadata about a block/blocks from RPC
 /// Accepts workers to decode blocks and a URL for the RPC
 pub struct Metadata<B: BlockT> {
-    // TODO it would be nice to be able to get state
-    // from the database without holding two references
-    // but would require a re-thinking of 'ActorPool'
     addr: Address<ActorPool<super::Database>>,
     conn: DbConn,
     rpc: Rpc<B>,
@@ -61,7 +57,6 @@ impl<B: BlockT> Metadata<B> {
 }
 
 impl<B: BlockT> Actor for Metadata<B> {}
-
 #[async_trait::async_trait]
 impl<B> Handler<Block<B>> for Metadata<B>
 where

--- a/archive/src/backend/frontend.rs
+++ b/archive/src/backend/frontend.rs
@@ -63,7 +63,7 @@ where
     let backend = Arc::new(ReadOnlyBackend::new(db, true));
 
     let executor = NativeExecutor::<Dispatch>::new(
-        WasmExecutionMethod::Compiled,
+        WasmExecutionMethod::Interpreted,
         Some(wasm_pages),
         block_workers as usize,
     );

--- a/archive/src/database.rs
+++ b/archive/src/database.rs
@@ -62,13 +62,8 @@ impl Database {
     }
 
     /// Start the database with a pre-defined pool
-    #[allow(unused)]
     pub fn with_pool(url: String, pool: PgPool) -> Self {
         Self { pool, url }
-    }
-
-    pub fn pool(&self) -> &sqlx::Pool<Postgres> {
-        &self.pool
     }
 
     pub async fn insert(&self, data: impl Insert) -> ArchiveResult<u64> {

--- a/archive/src/database.rs
+++ b/archive/src/database.rs
@@ -71,39 +71,11 @@ impl Database {
     pub async fn insert(&self, data: impl Insert) -> ArchiveResult<u64> {
         let mut conn = self.pool.acquire().await?;
         let res = data.insert(&mut conn).await?;
-        // we HAVE to ensure the connection is dropped, otherwise we may never reclaim it
-        std::mem::drop(conn);
         Ok(res)
-    }
-
-    /// Inserts an some object into a database
-    ///
-    /// # Panics
-    /// panics if sql encounters an error
-    pub async fn insert_unchecked(&self, data: impl Insert) -> u64 {
-        let mut conn = self.conn_unchecked().await;
-        let res = match data.insert(&mut conn).await {
-            Ok(v) => v,
-            Err(e) => {
-                panic!("{}", e.to_string());
-            }
-        };
-        // we HAVE to ensure the connection is dropped, otherwise we may never reclaim it
-        std::mem::drop(conn);
-        res
     }
 
     pub async fn conn(&self) -> ArchiveResult<DbConn> {
         self.pool.acquire().await.map_err(Into::into)
-    }
-
-    pub async fn conn_unchecked(&self) -> DbConn {
-        match self.pool.acquire().await {
-            Ok(v) => v,
-            Err(e) => {
-                panic!("{}", e.to_string());
-            }
-        }
     }
 }
 

--- a/archive/src/database/queries.rs
+++ b/archive/src/database/queries.rs
@@ -16,7 +16,6 @@
 
 //! Common Sql queries on Archive Database abstracted into rust functions
 
-use super::batch::Batch;
 use crate::{
     error::{ArchiveResult, Error as ArchiveError},
     sql_block_builder::SqlBlock,

--- a/archive/src/threadpools.rs
+++ b/archive/src/threadpools.rs
@@ -58,7 +58,7 @@ where
         let res_sender = sender.clone();
         let handle = jod_thread::spawn(move || -> ArchiveResult<()> {
             let pool = ThreadedBlockFetcher::new(ctx, threads)?;
-            let mut pool = BlockScheduler::new(pool, 1000, Ordering::Ascending);
+            let mut pool = BlockScheduler::new("fetch", pool, 1000, Ordering::Ascending);
             'sched: loop {
                 // ideally, there should be a way to check if senders
                 // have dropped: https://github.com/zesterer/flume/issues/32
@@ -150,7 +150,7 @@ where
         let res_sender = sender.clone();
         let handle = jod_thread::spawn(move || -> ArchiveResult<()> {
             let pool = BlockExecPool::<B, R, A>::new(threads, client, backend)?;
-            let mut pool = BlockScheduler::new(pool, 256, Ordering::Ascending);
+            let mut pool = BlockScheduler::new("exec", pool, 256, Ordering::Ascending);
             'sched: loop {
                 thread::sleep(Duration::from_millis(50));
                 // ideally, there should be a way to check if senders

--- a/archive/src/threadpools/block_scheduler.rs
+++ b/archive/src/threadpools/block_scheduler.rs
@@ -31,9 +31,14 @@ use codec::{Decode, Encode};
 use hashbrown::HashSet;
 use std::{collections::BinaryHeap, fmt::Debug};
 
+// TODO Get rid of the HashSet redundant checking for duplicates if possible.
+// Or only store hashes and not the full bytes of the struct.
+// TODO Just store generic strut instead of the encoded version of the struct.
+// I doubt that it is much more memory efficient
+
 /// Encoded version of the data coming in
 /// the and identifier is kept decoded so that it may be sorted
-/// this is more memory efficient than keeping the rust representation in memory
+/// this could be more memory efficient than keeping the rust representation in memory
 #[derive(Clone)]
 struct EncodedIn<I: PriorityIdent> {
     enc: Vec<u8>,
@@ -203,46 +208,3 @@ where
         Ok(())
     }
 }
-
-/*
-/// Denomination of bytes/megabytes/kilobytes
-enum Deno {
-    #[allow(unused)]
-    Bytes,
-    KB,
-    MB,
-}
-
-fn size_of_encoded<I: PriorityIdent>(deno: Deno, items: &[EncodedIn<I>]) -> usize {
-    let byte_size = || {
-        let mut total_size = 0;
-        for i in items.iter() {
-            let vec_size_bytes = i.enc.len();
-            let ident_size = std::mem::size_of::<I::Ident>();
-            total_size += vec_size_bytes + ident_size;
-        }
-        total_size
-    };
-    match deno {
-        Deno::Bytes => byte_size(),
-        Deno::KB => byte_size() / 1024,
-        Deno::MB => byte_size() / 1024 / 1024,
-    }
-}
-
-fn size_of_decoded<I: PriorityIdent>(deno: Deno, items: &[I]) -> usize {
-    let byte_size = || {
-        let mut total_size = 0;
-        for _ in items.iter() {
-            let item_size_bytes = std::mem::size_of::<I>();
-            total_size += item_size_bytes;
-        }
-        total_size
-    };
-    match deno {
-        Deno::Bytes => byte_size(),
-        Deno::KB => byte_size() / 1024,
-        Deno::MB => byte_size() / 1024 / 1024,
-    }
-}
-*/

--- a/archive/src/threadpools/block_scheduler.rs
+++ b/archive/src/threadpools/block_scheduler.rs
@@ -157,7 +157,7 @@ where
         } else if delta == 0 && self.queue.len() <= self.max_size {
             self.add_work(self.queue.len())?;
         } else {
-            log::info!(
+            log::debug!(
                 "sched-{}: Queue Length: {}, Delta: {}, added: {}, finished: {}",
                 self.name,
                 self.queue.len(),

--- a/archive/src/types.rs
+++ b/archive/src/types.rs
@@ -55,7 +55,7 @@ pub struct Metadata {
 }
 
 impl Message for Metadata {
-    type Result = Result<(), ArchiveError>;
+    type Result = ();
 }
 
 impl Metadata {
@@ -79,7 +79,7 @@ pub struct Block<B: BlockT> {
 }
 
 impl<B: BlockT> Message for Block<B> {
-    type Result = Result<(), ArchiveError>;
+    type Result = ();
 }
 
 impl<B: BlockT> Block<B> {
@@ -95,7 +95,7 @@ pub struct BatchBlock<B: BlockT> {
 }
 
 impl<B: BlockT> Message for BatchBlock<B> {
-    type Result = Result<(), ArchiveError>;
+    type Result = ();
 }
 
 impl<B: BlockT> BatchBlock<B> {
@@ -122,7 +122,7 @@ pub struct Storage<Block: BlockT> {
 }
 
 impl<Block: BlockT> Message for Storage<Block> {
-    type Result = Result<(), ArchiveError>;
+    type Result = ();
 }
 
 impl<Block: BlockT> Storage<Block> {

--- a/archive/src/util.rs
+++ b/archive/src/util.rs
@@ -154,18 +154,14 @@ pub fn init_logger(std: log::LevelFilter, file: log::LevelFilter) {
 
 /// log an error without doing anything else
 #[macro_export]
-macro_rules! print_on_err {
+macro_rules! p_err {
     ($e: expr) => {
         match $e {
-            Ok(_) => (),
-            Err(e) => log::error!("{:?}", e),
+            Ok(v) => v,
+            Err(e) => {
+                log::error!("{}", e.to_string());
+                panic!();
+            }
         };
-    };
-}
-
-#[macro_export]
-macro_rules! archive_answer {
-    ($ctx: expr, $ans: expr) => {
-        answer!($ctx, $ans).map_err(|_| crate::error::Error::from("Could not answer"))
     };
 }

--- a/polkadot-archive/test_conf.toml
+++ b/polkadot-archive/test_conf.toml
@@ -16,7 +16,7 @@ cache_size = 128
 # memory usage
 block_workers = 4
 # Number of 64KB Heap Pages to allocate for WASM execution
-wasm_pages = 128
+wasm_pages = 512
 
 db_host = "localhost"
 db_port = "5432"

--- a/polkadot-archive/test_conf.toml
+++ b/polkadot-archive/test_conf.toml
@@ -14,9 +14,9 @@ cache_size = 128
 # else the wasm executor will run out of memory. This also increases substrate-archives
 # Generally, you want 32 pages per block worker
 # memory usage
-block_workers = 8
+block_workers = 4
 # Number of 64KB Heap Pages to allocate for WASM execution
-wasm_pages = 512
+wasm_pages = 128
 
 db_host = "localhost"
 db_port = "5432"

--- a/polkadot-archive/test_conf.toml
+++ b/polkadot-archive/test_conf.toml
@@ -14,9 +14,9 @@ cache_size = 128
 # else the wasm executor will run out of memory. This also increases substrate-archives
 # Generally, you want 32 pages per block worker
 # memory usage
-block_workers = 4
+block_workers = 2
 # Number of 64KB Heap Pages to allocate for WASM execution
-wasm_pages = 512
+wasm_pages = 256
 
 db_host = "localhost"
 db_port = "5432"


### PR DESCRIPTION
This PR aims to decouple actors from the state they managed. For example, database connections are currently handed out judiciously, which makes bugs originating from a database query hard to track down. Any state to do with the database should be accessed from the database actor.

Memory Usage around ~300MB when caught up