### PR TITLE
do not print postgres url in plaintext

### DIFF
--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -30,7 +30,6 @@ use std::string::ToString;
 pub async fn migrate<T: ToString>(conf: T) -> Result<String> {
     let url = conf.to_string();
     let mut conn = PgConnection::connect(&url).await?;
-    log::info!("Running migrations for {}", url);
     sqlx::migrate!("./src/migrations/").run(&mut conn).await?;
     Ok(url)
 }


### PR DESCRIPTION
Pretty self-explanatory -- this could be problematic in some environments from a security standpoint. Ideally we could just print the name of the database to logs when we do migrations, but this PR is just a one-line change that removes the line printing the full URL which includes the database password.