### PR TITLE
Tweaks to Indexing & small bugfixes

### DIFF
--- a/bin/polkadot-archive/Cargo.lock
+++ b/bin/polkadot-archive/Cargo.lock
@@ -4420,7 +4420,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.0.3",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "rustc_version",
  "smallvec 0.6.13",
  "winapi 0.3.9",
@@ -4435,7 +4435,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.0.3",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec 1.6.1",
  "winapi 0.3.9",
 ]
@@ -4450,7 +4450,7 @@ dependencies = [
  "cloudabi 0.1.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec 1.6.1",
  "winapi 0.3.9",
 ]
@@ -5360,7 +5360,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc",
+ "rand_hc 0.2.0",
  "rand_pcg",
 ]
 
@@ -5373,6 +5373,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.0",
  "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -5447,6 +5448,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
+]
+
+[[package]]
 name = "rand_pcg"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5502,13 +5512,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
  "getrandom 0.1.15",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "rust-argon2",
 ]
 
@@ -8225,14 +8244,14 @@ checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "rand 0.7.3",
- "redox_syscall",
+ "rand 0.8.1",
+ "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -8764,7 +8783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.3.23",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/bin/polkadot-archive/Cargo.lock
+++ b/bin/polkadot-archive/Cargo.lock
@@ -2436,9 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
 dependencies = [
  "either",
 ]
@@ -8034,7 +8034,7 @@ dependencies = [
  "futures 0.3.9",
  "hashbrown",
  "hex",
- "itertools 0.9.0",
+ "itertools 0.10.0",
  "itoa",
  "jod-thread",
  "log",

--- a/substrate-archive/src/actors.rs
+++ b/substrate-archive/src/actors.rs
@@ -22,6 +22,7 @@ mod workers;
 use std::marker::PhantomData;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
+use std::time::Duration;
 
 use coil::Job as _;
 use futures::{future::BoxFuture, FutureExt};
@@ -205,7 +206,7 @@ where
 		let runner = coil::Runner::builder(env, crate::TaskExecutor, &pool)
 			.register_job::<crate::tasks::execute_block::Job<B, R, C, D>>()
 			.num_threads(ctx.workers)
-			.timeout(std::time::Duration::from_secs(20))
+			.timeout(Duration::from_secs(20))
 			.max_tasks(64)
 			.build()?;
 

--- a/substrate-archive/src/actors.rs
+++ b/substrate-archive/src/actors.rs
@@ -269,7 +269,6 @@ where
 	/// from the task queue.
 	/// If any are found, they are re-queued.
 	async fn restore_missing_storage(conn: &mut sqlx::PgConnection) -> Result<()> {
-		log::info!("Restoring missing storage entries...");
 		let blocks: HashSet<u32> = queries::get_all_blocks::<B>(conn)
 			.await?
 			.map(|b| Ok((*b?.header().number()).into()))
@@ -288,7 +287,7 @@ where
 				.into_iter()
 				.map(|b| crate::tasks::execute_block::<B, R, C, D>(b.inner.block, PhantomData))
 				.collect();
-		log::info!("Restoring {} missing storage entries", jobs.len());
+		log::info!("Restoring {} missing storage entries. This could take a few minutes...", jobs.len());
 		coil::JobExt::enqueue_batch(jobs, &mut *conn).await?;
 		log::info!("Storage restored");
 		Ok(())

--- a/substrate-archive/src/actors/workers/metadata.rs
+++ b/substrate-archive/src/actors/workers/metadata.rs
@@ -80,7 +80,7 @@ impl<B: BlockT + Unpin> MetadataActor<B> {
 		for b in versions.iter() {
 			self.meta_checker(b.spec, b.inner.block.hash()).await?;
 		}
-		self.addr.send(blks.into()).await?;
+		self.addr.send(blks.into()).await?.await;
 		Ok(())
 	}
 }

--- a/substrate-archive/src/actors/workers/storage_aggregator.rs
+++ b/substrate-archive/src/actors/workers/storage_aggregator.rs
@@ -44,7 +44,7 @@ where
 	async fn handle_storage(&mut self, ctx: &mut Context<Self>) -> Result<()> {
 		let storage = std::mem::take(&mut self.storage);
 		if !storage.is_empty() {
-			log::info!("Indexing storage {} bps", storage.len());
+			log::info!("Indexing {} storage entries", storage.len());
 			let send_result = self.db.send(BatchStorage::new(storage).into()).await?;
 			// handle_while the actual insert is happening, not the send
 			ctx.handle_while(self, send_result).await;

--- a/substrate-archive/src/actors/workers/storage_aggregator.rs
+++ b/substrate-archive/src/actors/workers/storage_aggregator.rs
@@ -44,7 +44,7 @@ where
 	async fn handle_storage(&mut self, ctx: &mut Context<Self>) -> Result<()> {
 		let storage = std::mem::take(&mut self.storage);
 		if !storage.is_empty() {
-			log::info!("Indexing {} storage entries", storage.len());
+			log::info!("Indexing {} blocks of storage entries", storage.len());
 			let send_result = self.db.send(BatchStorage::new(storage).into()).await?;
 			// handle_while the actual insert is happening, not the send
 			ctx.handle_while(self, send_result).await;

--- a/substrate-archive/src/database.rs
+++ b/substrate-archive/src/database.rs
@@ -21,6 +21,8 @@ mod batch;
 pub mod listener;
 pub mod queries;
 
+use std::time::Duration;
+
 use async_trait::async_trait;
 use codec::Encode;
 use sqlx::prelude::*;
@@ -56,7 +58,7 @@ impl Database {
 		let pool = PgPoolOptions::new()
 			.min_connections(4)
 			.max_connections(28)
-			.idle_timeout(std::time::Duration::from_millis(3600)) // kill connections after 3.6 seconds of idle
+			.idle_timeout(Duration::from_millis(3600)) // kill connections after 3.6 seconds of idle
 			.connect(url.as_str())
 			.await?;
 		Ok(Self { pool, url })

--- a/substrate-archive/src/database.rs
+++ b/substrate-archive/src/database.rs
@@ -56,7 +56,7 @@ impl Database {
 		let pool = PgPoolOptions::new()
 			.min_connections(4)
 			.max_connections(28)
-			.idle_timeout(std::time::Duration::from_millis(3600)) // kill connections after 5 minutes of idle
+			.idle_timeout(std::time::Duration::from_millis(3600)) // kill connections after 3.6 seconds of idle
 			.connect(url.as_str())
 			.await?;
 		Ok(Self { pool, url })


### PR DESCRIPTION
- Decrease max tasks from 500 to 64. Having 500 tasks queued at once, while decreasing the amount of database queries, is unnecessary/uses more memory than it needs to.

- Increase timeout from 5 to 20 seconds. This is mostly inconsequential, however while running archive I noticed that occasionally some tasks would take 10-15 seconds to complete if it happened upon a long-running database operation. This results in some warnings which occurs less often with a higher timeout.

- Decrease Spawned Database actors from 8 to 4. Not much performance difference between the two (not that I noticed). See #185 and #184  however.

- Don't pollute block indexer with more `Crawl` messages than required
  - rather than `ctx.notify_interval` the blocks actor now spawns a future that awaits the `crawl` so that there is no more than 1 Crawl queued at once. A crawl can take anywhere from 10-335 seconds depending on number of blocks being crawled + inserted at once. In my experience, 10K blocks takes ~20seconds, 100K takes 335 seconds. I looked into trying to optimize postgres inserts on the blocks table for this, but it is a more difficult task than it seems.

- use `handle_while` in storage aggregator
   - afaiu this should handle pushing more storage to the `StorageAggregators` queue while waiting for the current database task (initiated by the `send` to the database) to complete. This keeps the Actors mailbox less full. In my testing it seemed to resulted in more consistent storage indexing.

- adding `awaits` in places where we should await. In `StorageAggregator`, we now wait for the storage to be inserted before sending another database task. In `Metadata` actor we wait for blocks to be inserted before moving on to the next message.
This should decrease the amount of database connections we are using, as well as reduce memory use, since we don't have a bunch of tasks queued for database insertion. May help quell #161 
   