### PR TITLE
Update Substrate / Deny Dead Code / CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --tests
+          args: --all-targets
 
       - name: Check Code For `node-template-archive`
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --tests
 
       - name: Check Code For `node-template-archive`
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,19 +346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
-name = "async-tls"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f23d769dbf1838d5df5156e7b1ad404f4c463d1ac2c6aeb6cd943630f8a8400"
-dependencies = [
- "futures-core",
- "futures-io",
- "rustls 0.19.0",
- "webpki",
- "webpki-roots",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +354,19 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.60",
+]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4401f0a3622dad2e0763fa79e0eb328bc70fb7dccfdd645341f00d671247d6"
+dependencies = [
+ "bytes 1.0.0",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite 0.2.4",
 ]
 
 [[package]]
@@ -491,7 +491,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "which",
+ "which 3.1.1",
 ]
 
 [[package]]
@@ -1326,7 +1326,7 @@ dependencies = [
  "impl-rlp",
  "impl-serde",
  "primitive-types",
- "uint 0.9.0",
+ "uint",
 ]
 
 [[package]]
@@ -1422,7 +1422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
- "rand 0.8.1",
+ "rand 0.8.2",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1468,7 +1468,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1504,7 +1504,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1520,7 +1520,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "12.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1556,7 +1556,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -1590,7 +1590,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.0",
@@ -1606,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1761,6 +1761,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-rustls"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1387e07917c711fb4ee4f48ea0adb04a3c9739e53ef85bf43ae1edc2937a8b"
+dependencies = [
+ "futures-io",
+ "rustls 0.19.0",
+ "webpki",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,18 +1817,6 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
-]
-
-[[package]]
-name = "futures_codec"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
-dependencies = [
- "bytes 0.5.6",
- "futures 0.3.12",
- "memchr",
- "pin-project 0.4.27",
 ]
 
 [[package]]
@@ -2434,6 +2433,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
@@ -2612,7 +2620,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "bitvec 0.17.4",
  "frame-executive",
@@ -2773,12 +2781,12 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e17c636b5fe5ff900ccc2840b643074bfac321551d821243a781d0d46f06588"
+checksum = "d5133112ce42be9482f6a87be92a605dd6bbc9e93c297aee77d172ff06908f3a"
 dependencies = [
  "atomic",
- "bytes 0.5.6",
+ "bytes 1.0.0",
  "futures 0.3.12",
  "lazy_static",
  "libp2p-core",
@@ -2805,9 +2813,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cb706da14c064dce54d8864ade6836b3486b51689300da74eeb7053aa4551e"
+checksum = "dad04d3cef6c1df366a6ab58c9cf8b06497699e335d83ac2174783946ff847d6"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -2824,7 +2832,7 @@ dependencies = [
  "parity-multiaddr",
  "parking_lot 0.11.1",
  "pin-project 1.0.4",
- "prost",
+ "prost 0.7.0",
  "prost-build",
  "rand 0.7.3",
  "ring",
@@ -2832,7 +2840,7 @@ dependencies = [
  "sha2 0.9.2",
  "smallvec 1.6.1",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "void",
  "zeroize",
 ]
@@ -2849,9 +2857,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e09bab25af01326b4ed9486d31325911437448edda30bc57681502542d49f20"
+checksum = "5153b6db68fd4baa3b304e377db744dd8fea8ff4e4504509ee636abcde88d3e3"
 dependencies = [
  "futures 0.3.12",
  "libp2p-core",
@@ -2860,15 +2868,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43bc51a9bc3780288c526615ba0f5f8216820ea6dcc02b89e8daee526c5fccb"
+checksum = "b40fb36a059b7a8cce1514bd8b546fa612e006c9937caa7f5950cb20021fe91e"
 dependencies = [
  "futures 0.3.12",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost",
+ "prost 0.7.0",
  "prost-build",
  "smallvec 1.6.1",
  "wasm-timer",
@@ -2876,35 +2884,35 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe68563ee33f3848293919afd61470ebcdea4e757a36cc2c33a5508abec2216"
+checksum = "456f5de8e283d7800ca848b9b9a4e2a578b790bd8ae582b885e831353cf0e5df"
 dependencies = [
  "arrayvec 0.5.2",
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes 1.0.0",
  "either",
  "fnv",
  "futures 0.3.12",
- "futures_codec",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost",
+ "prost 0.7.0",
  "prost-build",
  "rand 0.7.3",
  "sha2 0.9.2",
  "smallvec 1.6.1",
- "uint 0.8.5",
- "unsigned-varint",
+ "uint",
+ "unsigned-varint 0.6.0",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9e12688e8f14008c950c1efde587cb44dbf316fa805f419cd4e524991236f5"
+checksum = "b974db63233fc0e199f4ede7794294aae285c96f4b6010f853eac4099ef08590"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -2923,35 +2931,35 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3200fbe6608e623bd9efa459cc8bafa0e4efbb0a2dfcdd0e1387ff4181264b"
+checksum = "2705dc94b01ab9e3779b42a09bbf3712e637ed213e875c30face247291a85af0"
 dependencies = [
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes 1.0.0",
  "futures 0.3.12",
- "futures_codec",
  "libp2p-core",
  "log",
  "nohash-hasher",
  "parking_lot 0.11.1",
  "rand 0.7.3",
  "smallvec 1.6.1",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0580e0d18019d254c9c349c03ff7b22e564b6f2ada70c045fc39738e144f2139"
+checksum = "4aca322b52a0c5136142a7c3971446fb1e9964923a526c9cc6ef3b7c94e57778"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.0",
  "curve25519-dalek 3.0.0",
  "futures 0.3.12",
  "lazy_static",
  "libp2p-core",
  "log",
- "prost",
+ "prost 0.7.0",
  "prost-build",
  "rand 0.7.3",
  "sha2 0.9.2",
@@ -2963,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b2ec86a18cbf09d7df440e7786a2409640c774e476e9a3b4d031382c3d7588"
+checksum = "6f3813276d0708c8db0f500d8beda1bda9ad955723b9cb272c41f4727256f73c"
 dependencies = [
  "futures 0.3.12",
  "libp2p-core",
@@ -2978,12 +2986,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620e2950decbf77554b5aed3824f7d0e2c04923f28c70f9bff1a402c47ef6b1e"
+checksum = "d37637a4b33b5390322ccc068a33897d0aa541daf4fec99f6a7efbf37295346e"
 dependencies = [
  "async-trait",
- "bytes 0.5.6",
+ "bytes 1.0.0",
  "futures 0.3.12",
  "libp2p-core",
  "libp2p-swarm",
@@ -2992,15 +3000,15 @@ dependencies = [
  "minicbor",
  "rand 0.7.3",
  "smallvec 1.6.1",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf5894ee1ee63a38aa58d58a16e3dcf7ede6b59ea7b22302c00c1a41d7aec41"
+checksum = "22ea8c69839a0e593c8c6a24282cb234d48ac37be4153183f4914e00f5303e75"
 dependencies = [
  "either",
  "futures 0.3.12",
@@ -3014,15 +3022,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2113a7dab2b502c55fe290910cd7399a2aa04fe70a2f5a415a87a1db600c0e"
+checksum = "3dbd3d7076a478ac5a6aca55e74bdc250ac539b95de09b9d09915e0b8d01a6b2"
 dependencies = [
- "async-std",
+ "async-io",
  "futures 0.3.12",
  "futures-timer 3.0.2",
- "if-addrs",
+ "if-watch",
  "ipnet",
+ "libc",
  "libp2p-core",
  "log",
  "socket2",
@@ -3030,9 +3039,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-wasm-ext"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cd44ea05a4523f40183f60ab6e6a80e400a5ddfc98b0df1c55edeb85576cd9"
+checksum = "6149c46cb76935c80bc8be6ec6e3ebd5f5e1679765a255fb34331d54610f15dd"
 dependencies = [
  "futures 0.3.12",
  "js-sys",
@@ -3044,29 +3053,27 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "270c80528e21089ea25b41dd1ab8fd834bdf093ebee422fed3b68699a857a083"
+checksum = "d3b1c6a3431045da8b925ed83384e4c5163e14b990572307fca9c507435d4d22"
 dependencies = [
- "async-tls",
  "either",
  "futures 0.3.12",
+ "futures-rustls",
  "libp2p-core",
  "log",
  "quicksink",
- "rustls 0.19.0",
  "rw-stream-sink",
  "soketto",
  "url 2.2.0",
- "webpki",
  "webpki-roots",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36799de9092c35782f080032eddbc8de870f94a0def87cf9f8883efccd5cacf0"
+checksum = "490b8b27fc40fe35212df1b6a3d14bffaa4117cbff956fdc2892168a371102ad"
 dependencies = [
  "futures 0.3.12",
  "libp2p-core",
@@ -3182,9 +3189,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be716eb6878ca2263eb5d00a781aa13264a794f519fe6af4fbb2668b2d5441c0"
+checksum = "3aae342b73d57ad0b8b364bd12584819f2c1fe9114285dfcf8b0722607671635"
 dependencies = [
  "hashbrown",
 ]
@@ -3297,6 +3304,15 @@ dependencies = [
  "keccak",
  "rand_core 0.5.1",
  "zeroize",
+]
+
+[[package]]
+name = "metered-channel"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
+dependencies = [
+ "futures 0.3.12",
+ "futures-timer 3.0.2",
 ]
 
 [[package]]
@@ -3426,7 +3442,7 @@ dependencies = [
  "generic-array 0.14.4",
  "multihash-derive",
  "sha2 0.9.2",
- "unsigned-varint",
+ "unsigned-varint 0.5.1",
 ]
 
 [[package]]
@@ -3451,16 +3467,16 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "multistream-select"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda822043bba2d6da31c4e14041f9794f8fb130a5959289038d0b809d8888614"
+checksum = "10ddc0eb0117736f19d556355464fc87efc8ad98b29e3fd84f02531eb6e90840"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.0",
  "futures 0.3.12",
  "log",
  "pin-project 1.0.4",
  "smallvec 1.6.1",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
 ]
 
 [[package]]
@@ -3691,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3707,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3722,7 +3738,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3747,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3761,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3775,7 +3791,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3790,7 +3806,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3804,8 +3820,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3819,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3840,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3856,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3875,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3891,7 +3907,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3905,7 +3921,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3920,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3934,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3949,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3964,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3977,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -3992,7 +4008,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4007,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4027,7 +4043,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4041,7 +4057,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4061,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -4072,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4086,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4103,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4117,11 +4133,10 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
- "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "serde",
  "smallvec 1.6.1",
@@ -4134,14 +4149,13 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "serde",
  "sp-api",
  "sp-blockchain",
  "sp-core",
@@ -4152,20 +4166,18 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
- "frame-support",
+ "pallet-transaction-payment",
  "parity-scale-codec",
- "serde",
  "sp-api",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
 name = "pallet-treasury"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4180,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4195,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4222,9 +4234,9 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180cd097078b337d2ba6400c6a67b181b38b611273cb1d8d12f3d8d5d8eaaacb"
+checksum = "8bfda2e46fc5e14122649e2645645a81ee5844e0fb2e727ef560cc71a8b2d801"
 dependencies = [
  "arrayref",
  "bs58",
@@ -4234,15 +4246,15 @@ dependencies = [
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "url 2.2.0",
 ]
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
+checksum = "79602888a81ace83e3d1d4b2873286c1f5f906c84db667594e8db8da3506c383"
 dependencies = [
  "arrayvec 0.5.2",
  "bitvec 0.17.4",
@@ -4614,7 +4626,7 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.7.30"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -4625,7 +4637,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -4638,8 +4650,9 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
+ "bitvec 0.17.4",
  "futures 0.3.12",
  "futures-timer 3.0.2",
  "kvdb",
@@ -4659,7 +4672,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-proposer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -4683,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -4699,19 +4712,22 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-jaeger",
  "polkadot-node-primitives",
  "polkadot-primitives",
  "sc-network",
+ "strum 0.20.0",
+ "thiserror",
+ "zstd",
 ]
 
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "futures 0.3.12",
  "parity-scale-codec",
@@ -4725,7 +4741,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4755,11 +4771,12 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "async-trait",
  "futures 0.3.12",
  "futures-timer 3.0.2",
+ "metered-channel",
  "parity-scale-codec",
  "pin-project 1.0.4",
  "polkadot-node-jaeger",
@@ -4780,7 +4797,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "async-trait",
  "futures 0.3.12",
@@ -4798,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "derive_more",
  "futures 0.3.12",
@@ -4821,7 +4838,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "bitvec 0.17.4",
  "frame-system",
@@ -4848,7 +4865,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "jsonrpc-core",
  "pallet-transaction-payment-rpc",
@@ -4878,7 +4895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "bitvec 0.17.4",
  "frame-executive",
@@ -4943,7 +4960,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "bitvec 0.17.4",
  "frame-support",
@@ -4979,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "bitvec 0.17.4",
  "derive_more",
@@ -4996,7 +5013,7 @@ dependencies = [
  "pallet-vesting",
  "parity-scale-codec",
  "polkadot-primitives",
- "rand 0.8.1",
+ "rand 0.8.2",
  "rand_chacha 0.3.0",
  "rustc-hex",
  "serde",
@@ -5016,7 +5033,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.8.3"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "frame-benchmarking",
  "frame-system-rpc-runtime-api",
@@ -5048,6 +5065,7 @@ dependencies = [
  "sc-consensus-slots",
  "sc-executor",
  "sc-finality-grandpa",
+ "sc-finality-grandpa-warp-sync",
  "sc-network",
  "sc-service",
  "sc-telemetry",
@@ -5081,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -5152,7 +5170,7 @@ dependencies = [
  "impl-codec",
  "impl-rlp",
  "impl-serde",
- "uint 0.9.0",
+ "uint",
 ]
 
 [[package]]
@@ -5239,25 +5257,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
  "bytes 0.5.6",
- "prost-derive",
+ "prost-derive 0.6.1",
+]
+
+[[package]]
+name = "prost"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+dependencies = [
+ "bytes 1.0.0",
+ "prost-derive 0.7.0",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.0",
  "heck",
- "itertools 0.8.2",
+ "itertools 0.9.0",
  "log",
  "multimap",
  "petgraph",
- "prost",
+ "prost 0.7.0",
  "prost-types",
  "tempfile",
- "which",
+ "which 4.0.2",
 ]
 
 [[package]]
@@ -5274,13 +5302,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-types"
-version = "0.6.1"
+name = "prost-derive"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
- "bytes 0.5.6",
- "prost",
+ "anyhow",
+ "itertools 0.9.0",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+dependencies = [
+ "bytes 1.0.0",
+ "prost 0.7.0",
 ]
 
 [[package]]
@@ -5369,9 +5410,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
@@ -5602,9 +5643,9 @@ dependencies = [
 
 [[package]]
 name = "retain_mut"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e005d658ad26eacc2b6c506dfde519f4e277e328d0eb3379ca61647d70a8f531"
+checksum = "53552c6c49e1e13f1a203ef0080ab3bbef0beb570a528993e83df057a9d9bba1"
 
 [[package]]
 name = "ring"
@@ -5676,12 +5717,13 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "frame-executive",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
+ "hex-literal",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
@@ -5846,7 +5888,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5856,7 +5898,7 @@ dependencies = [
  "libp2p",
  "log",
  "parity-scale-codec",
- "prost",
+ "prost 0.7.0",
  "prost-build",
  "rand 0.7.3",
  "sc-client-api",
@@ -5874,7 +5916,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -5897,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5914,7 +5956,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -5935,7 +5977,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -5946,7 +5988,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5980,7 +6022,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -6010,7 +6052,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -6021,7 +6063,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "fork-tree",
@@ -6066,7 +6108,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "futures 0.3.12",
@@ -6090,7 +6132,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -6103,7 +6145,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -6129,7 +6171,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "sc-client-api",
@@ -6143,7 +6185,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -6171,7 +6213,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -6187,7 +6229,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6202,13 +6244,14 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "finality-grandpa",
  "fork-tree",
  "futures 0.3.12",
  "futures-timer 3.0.2",
+ "linked-hash-map",
  "log",
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -6239,7 +6282,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -6261,9 +6304,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-finality-grandpa-warp-sync"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
+dependencies = [
+ "derive_more",
+ "futures 0.3.12",
+ "log",
+ "num-traits 0.2.14",
+ "parity-scale-codec",
+ "parking_lot 0.11.1",
+ "prost 0.6.1",
+ "sc-client-api",
+ "sc-finality-grandpa",
+ "sc-network",
+ "sc-service",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
 name = "sc-informant"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.12",
@@ -6281,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6301,7 +6364,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -6320,13 +6383,14 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "async-std",
  "async-trait",
+ "asynchronous-codec",
  "bitflags",
  "bs58",
- "bytes 0.5.6",
+ "bytes 1.0.0",
  "derive_more",
  "either",
  "erased-serde",
@@ -6334,18 +6398,18 @@ dependencies = [
  "fork-tree",
  "futures 0.3.12",
  "futures-timer 3.0.2",
- "futures_codec",
  "hex",
  "ip_network",
  "libp2p",
  "linked-hash-map",
  "linked_hash_set",
  "log",
+ "lru",
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.11.1",
  "pin-project 0.4.27",
- "prost",
+ "prost 0.7.0",
  "prost-build",
  "rand 0.7.3",
  "sc-block-builder",
@@ -6353,8 +6417,6 @@ dependencies = [
  "sc-peerset",
  "serde",
  "serde_json",
- "slog",
- "slog_derive",
  "smallvec 1.6.1",
  "sp-arithmetic",
  "sp-blockchain",
@@ -6364,7 +6426,7 @@ dependencies = [
  "sp-utils",
  "substrate-prometheus-endpoint",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "void",
  "wasm-timer",
  "zeroize",
@@ -6373,7 +6435,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -6382,13 +6444,14 @@ dependencies = [
  "lru",
  "sc-network",
  "sp-runtime",
+ "substrate-prometheus-endpoint",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-offchain"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -6415,7 +6478,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.12",
  "libp2p",
@@ -6428,7 +6491,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -6437,7 +6500,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.12",
  "hash-db",
@@ -6471,7 +6534,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "futures 0.3.12",
@@ -6495,7 +6558,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.1.30",
  "jsonrpc-core",
@@ -6513,7 +6576,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "directories",
  "exit-future",
@@ -6547,7 +6610,6 @@ dependencies = [
  "sc-transaction-pool",
  "serde",
  "serde_json",
- "slog",
  "sp-api",
  "sp-application-crypto",
  "sp-block-builder",
@@ -6577,7 +6639,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6592,7 +6654,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -6612,20 +6674,21 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
+ "chrono",
  "futures 0.3.12",
- "futures-timer 3.0.2",
  "libp2p",
  "log",
  "parking_lot 0.11.1",
  "pin-project 0.4.27",
  "rand 0.7.3",
  "serde",
- "slog",
- "slog-json",
- "slog-scope",
+ "serde_json",
+ "sp-utils",
  "take_mut",
+ "tracing",
+ "tracing-subscriber",
  "void",
  "wasm-timer",
 ]
@@ -6633,9 +6696,10 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "ansi_term 0.12.1",
+ "atty",
  "erased-serde",
  "lazy_static",
  "log",
@@ -6644,20 +6708,34 @@ dependencies = [
  "regex",
  "rustc-hash",
  "sc-telemetry",
+ "sc-tracing-proc-macro",
  "serde",
  "serde_json",
- "slog",
  "sp-tracing",
+ "thiserror",
  "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "sc-tracing-proc-macro"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "futures 0.3.12",
@@ -6679,7 +6757,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.12",
  "futures-diagnose",
@@ -7007,50 +7085,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
-name = "slog"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
-dependencies = [
- "erased-serde",
-]
-
-[[package]]
-name = "slog-json"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
-dependencies = [
- "chrono",
- "erased-serde",
- "serde",
- "serde_json",
- "slog",
-]
-
-[[package]]
-name = "slog-scope"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
-dependencies = [
- "arc-swap",
- "lazy_static",
- "slog",
-]
-
-[[package]]
-name = "slog_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
- "syn 1.0.60",
-]
-
-[[package]]
 name = "smallvec"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7131,7 +7165,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "sp-core",
@@ -7143,7 +7177,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -7159,7 +7193,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -7171,7 +7205,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7183,7 +7217,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.14",
@@ -7196,7 +7230,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7208,7 +7242,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7219,7 +7253,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7231,7 +7265,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.12",
  "log",
@@ -7249,7 +7283,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "serde",
  "serde_json",
@@ -7258,7 +7292,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -7284,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -7304,7 +7338,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7313,7 +7347,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -7325,7 +7359,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -7369,7 +7403,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -7378,7 +7412,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -7388,7 +7422,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7399,7 +7433,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -7416,7 +7450,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -7428,7 +7462,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.12",
  "hash-db",
@@ -7452,18 +7486,18 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "lazy_static",
  "sp-core",
  "sp-runtime",
- "strum",
+ "strum 0.16.0",
 ]
 
 [[package]]
 name = "sp-keystore"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7480,11 +7514,12 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-arithmetic",
+ "sp-core",
  "sp-npos-elections-compact",
  "sp-std",
 ]
@@ -7492,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -7503,7 +7538,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7513,7 +7548,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "backtrace",
 ]
@@ -7521,7 +7556,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "serde",
  "sp-core",
@@ -7530,7 +7565,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7551,7 +7586,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -7568,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7580,7 +7615,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "serde",
  "serde_json",
@@ -7589,7 +7624,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7602,7 +7637,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7612,7 +7647,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "hash-db",
  "log",
@@ -7634,12 +7669,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7652,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "sp-core",
@@ -7665,7 +7700,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -7679,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7692,7 +7727,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "futures 0.3.12",
@@ -7708,7 +7743,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7722,7 +7757,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.12",
  "futures-core",
@@ -7734,7 +7769,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7746,7 +7781,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -8014,7 +8049,16 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6138f8f88a16d90134763314e3fc76fa3ed6a7db4725d6acf9a3ef95a3188d22"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.16.0",
+]
+
+[[package]]
+name = "strum"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+dependencies = [
+ "strum_macros 0.20.1",
 ]
 
 [[package]]
@@ -8022,6 +8066,18 @@ name = "strum_macros"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
  "heck",
  "proc-macro2 1.0.24",
@@ -8147,7 +8203,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.12",
@@ -8170,7 +8226,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "async-std",
  "derive_more",
@@ -8263,7 +8319,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.1",
+ "rand 0.8.2",
  "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -8796,7 +8852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.7.3",
+ "rand 0.3.23",
  "static_assertions",
 ]
 
@@ -8811,18 +8867,6 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
-
-[[package]]
-name = "uint"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
-dependencies = [
- "byteorder",
- "crunchy",
- "rustc-hex",
- "static_assertions",
-]
 
 [[package]]
 name = "uint"
@@ -8908,11 +8952,17 @@ name = "unsigned-varint"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35581ff83d4101e58b582e607120c7f5ffb17e632a980b1f38334d76b36908b2"
 dependencies = [
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes 1.0.0",
  "futures-io",
  "futures-util",
- "futures_codec",
 ]
 
 [[package]]
@@ -9180,7 +9230,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "bitvec 0.17.4",
  "frame-executive",
@@ -9251,6 +9301,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "which"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+dependencies = [
+ "libc",
+ "thiserror",
 ]
 
 [[package]]
@@ -9336,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.8.22"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -9344,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.8.22"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -9360,7 +9420,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.8.22"
-source = "git+https://github.com/paritytech/polkadot?branch=master#ac5e2a08345e99486be46c911889914d99f07286"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.0",
@@ -9424,4 +9484,35 @@ dependencies = [
  "quote 1.0.7",
  "syn 1.0.60",
  "synstructure",
+]
+
+[[package]]
+name = "zstd"
+version = "0.5.4+zstd.1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69996ebdb1ba8b1517f61387a883857818a66c8a295f487b1ffd8fd9d2c82910"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "2.0.6+zstd.1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98aa931fb69ecee256d44589d19754e61851ae4769bf963b385119b1cc37a49e"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.4.18+zstd.1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6e8778706838f43f771d80d37787cb2fe06dafe89dd3aebaf6721b9eaec81"
+dependencies = [
+ "cc",
+ "glob",
+ "itertools 0.9.0",
+ "libc",
 ]

--- a/bin/node-template-archive/Cargo.lock
+++ b/bin/node-template-archive/Cargo.lock
@@ -343,19 +343,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
-name = "async-tls"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f23d769dbf1838d5df5156e7b1ad404f4c463d1ac2c6aeb6cd943630f8a8400"
-dependencies = [
- "futures-core",
- "futures-io",
- "rustls 0.19.0",
- "webpki",
- "webpki-roots 0.21.0",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +351,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4401f0a3622dad2e0763fa79e0eb328bc70fb7dccfdd645341f00d671247d6"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite 0.2.4",
 ]
 
 [[package]]
@@ -488,7 +488,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "which",
+ "which 3.1.1",
 ]
 
 [[package]]
@@ -1466,7 +1466,7 @@ dependencies = [
  "impl-rlp",
  "impl-serde",
  "primitive-types",
- "uint 0.9.0",
+ "uint",
 ]
 
 [[package]]
@@ -1624,7 +1624,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1642,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1660,7 +1660,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "Inflector",
  "chrono",
@@ -1683,7 +1683,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1699,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "12.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1759,7 +1759,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1769,7 +1769,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.0",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1940,6 +1940,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-rustls"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1387e07917c711fb4ee4f48ea0adb04a3c9739e53ef85bf43ae1edc2937a8b"
+dependencies = [
+ "futures-io",
+ "rustls 0.19.0",
+ "webpki",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,18 +1996,6 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
-]
-
-[[package]]
-name = "futures_codec"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
-dependencies = [
- "bytes 0.5.6",
- "futures 0.3.9",
- "memchr",
- "pin-project 0.4.27",
 ]
 
 [[package]]
@@ -2615,18 +2614,18 @@ checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
 dependencies = [
  "either",
 ]
@@ -2902,12 +2901,12 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e17c636b5fe5ff900ccc2840b643074bfac321551d821243a781d0d46f06588"
+checksum = "d5133112ce42be9482f6a87be92a605dd6bbc9e93c297aee77d172ff06908f3a"
 dependencies = [
  "atomic",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures 0.3.9",
  "lazy_static",
  "libp2p-core",
@@ -2940,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cb706da14c064dce54d8864ade6836b3486b51689300da74eeb7053aa4551e"
+checksum = "dad04d3cef6c1df366a6ab58c9cf8b06497699e335d83ac2174783946ff847d6"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -2967,7 +2966,7 @@ dependencies = [
  "sha2 0.9.2",
  "smallvec 1.6.1",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "void",
  "zeroize",
 ]
@@ -2984,9 +2983,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-deflate"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3257a41f376aa23f237231971fee7e350e4d8353cfcf233aef34d6d6b638f0c"
+checksum = "935893c0e5b6ca6ef60d5225aab9182f97c8c5671df2fa9dee8f4ed72a90e6eb"
 dependencies = [
  "flate2",
  "futures 0.3.9",
@@ -2995,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e09bab25af01326b4ed9486d31325911437448edda30bc57681502542d49f20"
+checksum = "5153b6db68fd4baa3b304e377db744dd8fea8ff4e4504509ee636abcde88d3e3"
 dependencies = [
  "futures 0.3.9",
  "libp2p-core",
@@ -3006,9 +3005,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd8cdd5ef1dd0b7346975477216d752de976b92e43051bc8bd808c372ea6cec"
+checksum = "b3c63dfa06581b24b1d12bf9815b43689a784424be217d6545c800c7c75a207f"
 dependencies = [
  "cuckoofilter",
  "fnv",
@@ -3024,35 +3023,35 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d489531aa9d4ba8726a08b3b74e21c2e10a518ad266ebca98d79040123ab0036"
+checksum = "12451ba9493e87c91baf2a6dffce9ddf1fbc807a0861532d7cf477954f8ebbee"
 dependencies = [
+ "asynchronous-codec",
  "base64 0.13.0",
  "byteorder",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "fnv",
  "futures 0.3.9",
- "futures_codec",
  "hex_fmt",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "lru_time_cache",
  "prost",
  "prost-build",
  "rand 0.7.3",
+ "regex",
  "sha2 0.9.2",
  "smallvec 1.6.1",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43bc51a9bc3780288c526615ba0f5f8216820ea6dcc02b89e8daee526c5fccb"
+checksum = "b40fb36a059b7a8cce1514bd8b546fa612e006c9937caa7f5950cb20021fe91e"
 dependencies = [
  "futures 0.3.9",
  "libp2p-core",
@@ -3066,16 +3065,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe68563ee33f3848293919afd61470ebcdea4e757a36cc2c33a5508abec2216"
+checksum = "456f5de8e283d7800ca848b9b9a4e2a578b790bd8ae582b885e831353cf0e5df"
 dependencies = [
  "arrayvec 0.5.2",
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes 1.0.1",
  "either",
  "fnv",
  "futures 0.3.9",
- "futures_codec",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3084,17 +3083,17 @@ dependencies = [
  "rand 0.7.3",
  "sha2 0.9.2",
  "smallvec 1.6.1",
- "uint 0.8.5",
- "unsigned-varint",
+ "uint",
+ "unsigned-varint 0.6.0",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9e12688e8f14008c950c1efde587cb44dbf316fa805f419cd4e524991236f5"
+checksum = "b974db63233fc0e199f4ede7794294aae285c96f4b6010f853eac4099ef08590"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -3113,29 +3112,29 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3200fbe6608e623bd9efa459cc8bafa0e4efbb0a2dfcdd0e1387ff4181264b"
+checksum = "2705dc94b01ab9e3779b42a09bbf3712e637ed213e875c30face247291a85af0"
 dependencies = [
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes 1.0.1",
  "futures 0.3.9",
- "futures_codec",
  "libp2p-core",
  "log",
  "nohash-hasher",
  "parking_lot 0.11.1",
  "rand 0.7.3",
  "smallvec 1.6.1",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0580e0d18019d254c9c349c03ff7b22e564b6f2ada70c045fc39738e144f2139"
+checksum = "4aca322b52a0c5136142a7c3971446fb1e9964923a526c9cc6ef3b7c94e57778"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "curve25519-dalek 3.0.0",
  "futures 0.3.9",
  "lazy_static",
@@ -3153,9 +3152,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b2ec86a18cbf09d7df440e7786a2409640c774e476e9a3b4d031382c3d7588"
+checksum = "6f3813276d0708c8db0f500d8beda1bda9ad955723b9cb272c41f4727256f73c"
 dependencies = [
  "futures 0.3.9",
  "libp2p-core",
@@ -3168,18 +3167,18 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7b1bdcbe46a3a2159c231601ed29645282653c0a96ce3a2ad8352c9fbe6800"
+checksum = "48e8c1ec305c9949351925cdc7196b9570f4330477f5e47fbf5bb340b57e26ed"
 dependencies = [
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes 1.0.1",
  "futures 0.3.9",
- "futures_codec",
  "libp2p-core",
  "log",
  "prost",
  "prost-build",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "void",
 ]
 
@@ -3199,12 +3198,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620e2950decbf77554b5aed3824f7d0e2c04923f28c70f9bff1a402c47ef6b1e"
+checksum = "d37637a4b33b5390322ccc068a33897d0aa541daf4fec99f6a7efbf37295346e"
 dependencies = [
  "async-trait",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures 0.3.9",
  "libp2p-core",
  "libp2p-swarm",
@@ -3213,15 +3212,15 @@ dependencies = [
  "minicbor",
  "rand 0.7.3",
  "smallvec 1.6.1",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf5894ee1ee63a38aa58d58a16e3dcf7ede6b59ea7b22302c00c1a41d7aec41"
+checksum = "22ea8c69839a0e593c8c6a24282cb234d48ac37be4153183f4914e00f5303e75"
 dependencies = [
  "either",
  "futures 0.3.9",
@@ -3235,15 +3234,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2113a7dab2b502c55fe290910cd7399a2aa04fe70a2f5a415a87a1db600c0e"
+checksum = "3dbd3d7076a478ac5a6aca55e74bdc250ac539b95de09b9d09915e0b8d01a6b2"
 dependencies = [
- "async-std",
+ "async-io",
  "futures 0.3.9",
  "futures-timer 3.0.2",
- "if-addrs",
+ "if-watch",
  "ipnet",
+ "libc",
  "libp2p-core",
  "log",
  "socket2",
@@ -3251,9 +3251,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-uds"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af05fe92c2a3aa320bc82a308ddb7b33bef3b060154c5a4b9fb0b01f15385fc0"
+checksum = "80ac51ce419f60be966e02103c17f67ff5dc4422ba83ba54d251d6c62a4ed487"
 dependencies = [
  "async-std",
  "futures 0.3.9",
@@ -3263,9 +3263,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-wasm-ext"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cd44ea05a4523f40183f60ab6e6a80e400a5ddfc98b0df1c55edeb85576cd9"
+checksum = "6149c46cb76935c80bc8be6ec6e3ebd5f5e1679765a255fb34331d54610f15dd"
 dependencies = [
  "futures 0.3.9",
  "js-sys",
@@ -3277,29 +3277,27 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "270c80528e21089ea25b41dd1ab8fd834bdf093ebee422fed3b68699a857a083"
+checksum = "d3b1c6a3431045da8b925ed83384e4c5163e14b990572307fca9c507435d4d22"
 dependencies = [
- "async-tls",
  "either",
  "futures 0.3.9",
+ "futures-rustls",
  "libp2p-core",
  "log",
  "quicksink",
- "rustls 0.19.0",
  "rw-stream-sink",
  "soketto",
  "url 2.2.0",
- "webpki",
  "webpki-roots 0.21.0",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36799de9092c35782f080032eddbc8de870f94a0def87cf9f8883efccd5cacf0"
+checksum = "490b8b27fc40fe35212df1b6a3d14bffaa4117cbff956fdc2892168a371102ad"
 dependencies = [
  "futures 0.3.9",
  "libp2p-core",
@@ -3415,9 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be716eb6878ca2263eb5d00a781aa13264a794f519fe6af4fbb2668b2d5441c0"
+checksum = "3aae342b73d57ad0b8b364bd12584819f2c1fe9114285dfcf8b0722607671635"
 dependencies = [
  "hashbrown",
 ]
@@ -3430,12 +3428,6 @@ checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
 ]
-
-[[package]]
-name = "lru_time_cache"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebac060fafad3adedd0c66a80741a92ff4bc8e94a273df2ba3770ab206f2e29a"
 
 [[package]]
 name = "mach"
@@ -3669,7 +3661,7 @@ dependencies = [
  "generic-array 0.14.4",
  "multihash-derive",
  "sha2 0.9.2",
- "unsigned-varint",
+ "unsigned-varint 0.5.1",
 ]
 
 [[package]]
@@ -3694,16 +3686,16 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "multistream-select"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda822043bba2d6da31c4e14041f9794f8fb130a5959289038d0b809d8888614"
+checksum = "10ddc0eb0117736f19d556355464fc87efc8ad98b29e3fd84f02531eb6e90840"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures 0.3.9",
  "log",
  "pin-project 1.0.4",
  "smallvec 1.6.1",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
 ]
 
 [[package]]
@@ -3778,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "node-template"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -3796,6 +3788,7 @@ dependencies = [
  "sc-rpc",
  "sc-rpc-api",
  "sc-service",
+ "sc-telemetry",
  "sc-transaction-pool",
  "sp-api",
  "sp-block-builder",
@@ -3832,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "node-template-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -4022,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4041,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4056,7 +4049,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4070,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4091,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4104,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4124,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4138,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "pallet-template"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4148,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4165,11 +4158,10 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
- "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "serde",
  "smallvec 1.6.1",
@@ -4182,14 +4174,13 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "serde",
  "sp-api",
  "sp-blockchain",
  "sp-core",
@@ -4200,14 +4191,12 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
- "frame-support",
+ "pallet-transaction-payment",
  "parity-scale-codec",
- "serde",
  "sp-api",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -4226,9 +4215,9 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f51a30667591b14f96068b2d12f1306d07a41ebd98239d194356d4d9707ac16"
+checksum = "8bfda2e46fc5e14122649e2645645a81ee5844e0fb2e727ef560cc71a8b2d801"
 dependencies = [
  "arrayref",
  "bs58",
@@ -4238,15 +4227,15 @@ dependencies = [
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "url 2.2.0",
 ]
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
+checksum = "79602888a81ace83e3d1d4b2873286c1f5f906c84db667594e8db8da3506c383"
 dependencies = [
  "arrayvec 0.5.2",
  "bitvec 0.17.4",
@@ -4401,7 +4390,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.0.3",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "rustc_version",
  "smallvec 0.6.13",
  "winapi 0.3.9",
@@ -4416,7 +4405,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.0.3",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec 1.6.1",
  "winapi 0.3.9",
 ]
@@ -4431,7 +4420,7 @@ dependencies = [
  "cloudabi 0.1.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec 1.6.1",
  "winapi 0.3.9",
 ]
@@ -4675,7 +4664,7 @@ dependencies = [
  "impl-codec",
  "impl-rlp",
  "impl-serde",
- "uint 0.9.0",
+ "uint",
 ]
 
 [[package]]
@@ -4748,40 +4737,40 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "heck",
- "itertools 0.8.2",
+ "itertools 0.9.0",
  "log",
  "multimap",
  "petgraph",
  "prost",
  "prost-types",
  "tempfile",
- "which",
+ "which 4.0.2",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
- "itertools 0.8.2",
+ "itertools 0.9.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -4789,11 +4778,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "prost",
 ]
 
@@ -4885,7 +4874,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc",
+ "rand_hc 0.2.0",
  "rand_pcg",
 ]
 
@@ -4898,6 +4887,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.0",
  "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -4972,6 +4962,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
+]
+
+[[package]]
 name = "rand_pcg"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5038,13 +5037,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
  "getrandom 0.1.15",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "rust-argon2",
 ]
 
@@ -5130,9 +5138,9 @@ dependencies = [
 
 [[package]]
 name = "retain_mut"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e005d658ad26eacc2b6c506dfde519f4e277e328d0eb3379ca61647d70a8f531"
+checksum = "53552c6c49e1e13f1a203ef0080ab3bbef0beb570a528993e83df057a9d9bba1"
 
 [[package]]
 name = "ring"
@@ -5335,7 +5343,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.9",
  "futures-timer 3.0.2",
@@ -5358,7 +5366,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5375,7 +5383,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -5396,7 +5404,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5407,9 +5415,8 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
- "atty",
  "chrono",
  "fdlimit",
  "futures 0.3.9",
@@ -5421,7 +5428,6 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "rpassword",
- "sc-cli-proc-macro",
  "sc-client-api",
  "sc-keystore",
  "sc-network",
@@ -5442,26 +5448,12 @@ dependencies = [
  "thiserror",
  "tiny-bip39",
  "tokio 0.2.23",
- "tracing",
- "tracing-log",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "sc-cli-proc-macro"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
 name = "sc-client-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5495,7 +5487,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5525,7 +5517,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5536,7 +5528,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "futures 0.3.9",
@@ -5567,7 +5559,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "fork-tree",
@@ -5612,7 +5604,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5625,7 +5617,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.9",
  "futures-timer 3.0.2",
@@ -5651,7 +5643,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "sc-client-api",
@@ -5665,7 +5657,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -5694,7 +5686,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -5710,7 +5702,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5725,7 +5717,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5743,13 +5735,14 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "finality-grandpa",
  "fork-tree",
  "futures 0.3.9",
  "futures-timer 3.0.2",
+ "linked-hash-map",
  "log",
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -5780,7 +5773,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.9",
@@ -5798,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5818,7 +5811,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -5837,13 +5830,14 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "async-std",
  "async-trait",
+ "asynchronous-codec",
  "bitflags",
  "bs58",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "derive_more",
  "either",
  "erased-serde",
@@ -5851,13 +5845,13 @@ dependencies = [
  "fork-tree",
  "futures 0.3.9",
  "futures-timer 3.0.2",
- "futures_codec",
  "hex",
  "ip_network",
  "libp2p",
  "linked-hash-map",
  "linked_hash_set",
  "log",
+ "lru",
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -5870,8 +5864,6 @@ dependencies = [
  "sc-peerset",
  "serde",
  "serde_json",
- "slog",
- "slog_derive",
  "smallvec 1.6.1",
  "sp-arithmetic",
  "sp-blockchain",
@@ -5881,7 +5873,7 @@ dependencies = [
  "sp-utils",
  "substrate-prometheus-endpoint",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "void",
  "wasm-timer",
  "zeroize",
@@ -5890,7 +5882,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.9",
  "futures-timer 3.0.2",
@@ -5899,13 +5891,14 @@ dependencies = [
  "lru",
  "sc-network",
  "sp-runtime",
+ "substrate-prometheus-endpoint",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-offchain"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -5932,7 +5925,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.9",
  "libp2p",
@@ -5945,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5954,7 +5947,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.9",
  "hash-db",
@@ -5988,7 +5981,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "futures 0.3.9",
@@ -6012,7 +6005,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.1.30",
  "jsonrpc-core",
@@ -6030,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "directories 3.0.1",
  "exit-future",
@@ -6064,7 +6057,6 @@ dependencies = [
  "sc-transaction-pool",
  "serde",
  "serde_json",
- "slog",
  "sp-api",
  "sp-application-crypto",
  "sp-block-builder",
@@ -6094,7 +6086,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6109,20 +6101,21 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
+ "chrono",
  "futures 0.3.9",
- "futures-timer 3.0.2",
  "libp2p",
  "log",
  "parking_lot 0.11.1",
  "pin-project 0.4.27",
  "rand 0.7.3",
  "serde",
- "slog",
- "slog-json",
- "slog-scope",
+ "serde_json",
+ "sp-utils",
  "take_mut",
+ "tracing",
+ "tracing-subscriber",
  "void",
  "wasm-timer",
 ]
@@ -6130,9 +6123,10 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "ansi_term 0.12.1",
+ "atty",
  "erased-serde",
  "lazy_static",
  "log",
@@ -6141,20 +6135,34 @@ dependencies = [
  "regex",
  "rustc-hash",
  "sc-telemetry",
+ "sc-tracing-proc-macro",
  "serde",
  "serde_json",
- "slog",
  "sp-tracing",
+ "thiserror",
  "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "sc-tracing-proc-macro"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "futures 0.3.9",
@@ -6176,7 +6184,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.9",
  "futures-diagnose",
@@ -6505,50 +6513,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
-name = "slog"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
-dependencies = [
- "erased-serde",
-]
-
-[[package]]
-name = "slog-json"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
-dependencies = [
- "chrono",
- "erased-serde",
- "serde",
- "serde_json",
- "slog",
-]
-
-[[package]]
-name = "slog-scope"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
-dependencies = [
- "arc-swap",
- "lazy_static",
- "slog",
-]
-
-[[package]]
-name = "slog_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "smallvec"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6629,7 +6593,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "sp-core",
@@ -6641,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6657,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6669,7 +6633,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6681,7 +6645,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6694,7 +6658,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6705,7 +6669,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6717,7 +6681,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.9",
  "log",
@@ -6735,7 +6699,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "serde",
  "serde_json",
@@ -6744,7 +6708,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.9",
  "futures-timer 3.0.2",
@@ -6770,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6784,7 +6748,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -6804,7 +6768,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6813,7 +6777,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6825,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6869,7 +6833,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -6878,7 +6842,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6888,7 +6852,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6899,7 +6863,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6916,7 +6880,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -6928,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.9",
  "hash-db",
@@ -6952,7 +6916,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6963,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6980,7 +6944,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6990,7 +6954,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "backtrace",
 ]
@@ -6998,7 +6962,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "serde",
  "sp-core",
@@ -7007,7 +6971,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7028,7 +6992,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -7045,7 +7009,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7057,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "serde",
  "serde_json",
@@ -7066,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7079,7 +7043,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7089,7 +7053,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "hash-db",
  "log",
@@ -7111,12 +7075,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7129,7 +7093,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "sp-core",
@@ -7142,7 +7106,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -7156,7 +7120,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7169,7 +7133,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "futures 0.3.9",
@@ -7185,7 +7149,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7199,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.3.9",
  "futures-core",
@@ -7211,7 +7175,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7223,7 +7187,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -7527,7 +7491,7 @@ dependencies = [
  "futures 0.3.9",
  "hashbrown",
  "hex",
- "itertools 0.9.0",
+ "itertools 0.10.0",
  "itoa",
  "jod-thread",
  "log",
@@ -7627,7 +7591,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "platforms",
 ]
@@ -7635,7 +7599,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.9",
@@ -7658,7 +7622,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7672,7 +7636,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -7739,14 +7703,14 @@ checksum = "ab0e7238dcc7b40a7be719a25365910f6807bd864f4cce6b2e6b873658e2b19d"
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "rand 0.7.3",
- "redox_syscall",
+ "rand 0.8.1",
+ "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -8277,18 +8241,6 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
-dependencies = [
- "byteorder",
- "crunchy",
- "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
-name = "uint"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
@@ -8365,11 +8317,17 @@ name = "unsigned-varint"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35581ff83d4101e58b582e607120c7f5ffb17e632a980b1f38334d76b36908b2"
 dependencies = [
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes 1.0.1",
  "futures-io",
  "futures-util",
- "futures_codec",
 ]
 
 [[package]]
@@ -8835,6 +8793,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "which"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+dependencies = [
+ "libc",
+ "thiserror",
 ]
 
 [[package]]

--- a/bin/polkadot-archive/Cargo.lock
+++ b/bin/polkadot-archive/Cargo.lock
@@ -180,7 +180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -345,19 +345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
-name = "async-tls"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f23d769dbf1838d5df5156e7b1ad404f4c463d1ac2c6aeb6cd943630f8a8400"
-dependencies = [
- "futures-core",
- "futures-io",
- "rustls 0.19.0",
- "webpki",
- "webpki-roots 0.21.0",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,7 +352,20 @@ checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4401f0a3622dad2e0763fa79e0eb328bc70fb7dccfdd645341f00d671247d6"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite 0.2.4",
 ]
 
 [[package]]
@@ -480,7 +480,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "which",
+ "which 3.1.1",
 ]
 
 [[package]]
@@ -829,7 +829,7 @@ dependencies = [
  "async-channel",
  "async-trait",
  "coil_proc_macro",
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
  "inventory",
  "itoa",
@@ -849,7 +849,7 @@ checksum = "6cce31ac045c7da7ea03e04b4c0d35bfdde70c7383c99a77bf337b1da4e593e1"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -1081,7 +1081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
 dependencies = [
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -1134,7 +1134,7 @@ checksum = "41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -1215,7 +1215,7 @@ checksum = "558e40ea573c374cf53507fd240b7ee2f5477df7cfebdb97323ec61c719399c5"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -1282,7 +1282,7 @@ checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -1337,7 +1337,7 @@ dependencies = [
  "impl-rlp",
  "impl-serde",
  "primitive-types",
- "uint 0.9.0",
+ "uint",
 ]
 
 [[package]]
@@ -1352,7 +1352,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
 ]
 
 [[package]]
@@ -1373,7 +1373,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
  "synstructure",
 ]
 
@@ -1418,7 +1418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8feb87a63249689640ac9c011742c33139204e3c134293d3054022276869133b"
 dependencies = [
  "either",
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 2.0.2",
  "log",
  "num-traits 0.2.14",
@@ -1433,7 +1433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
- "rand 0.8.1",
+ "rand 0.8.2",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1479,7 +1479,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1497,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "12.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1542,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1567,41 +1567,41 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "frame-system"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.0",
@@ -1617,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1671,9 +1671,9 @@ checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
 name = "futures"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70be434c505aee38639abccb918163b63158a4b4bb791b45b7023044bdc3c9c"
+checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1686,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01c61843314e95f96cc9245702248733a3a3d744e43e2e755e3c7af8348a0a9"
+checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1696,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8d3b0917ff63a2a96173133c02818fac4a746b0a57569d3baca9ec0e945e08"
+checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
 
 [[package]]
 name = "futures-cpupool"
@@ -1717,7 +1717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdcef58a173af8148b182684c9f2d5250875adbcaff7b5794073894f9d8634a9"
 dependencies = [
  "futures 0.1.30",
- "futures 0.3.9",
+ "futures 0.3.12",
  "lazy_static",
  "log",
  "parking_lot 0.9.0",
@@ -1728,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "futures-executor"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee9ca2f7eb4475772cf39dd1cd06208dce2670ad38f4d9c7262b3e15f127068"
+checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1740,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37c1a51b037b80922864b8eed90692c5cd8abd4c71ce49b77146caa47f3253b"
+checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
 
 [[package]]
 name = "futures-lite"
@@ -1761,27 +1761,38 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8719ca0e1f3c5e34f3efe4570ef2c0610ca6da85ae7990d472e9cbfba13664"
+checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "futures-rustls"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1387e07917c711fb4ee4f48ea0adb04a3c9739e53ef85bf43ae1edc2937a8b"
+dependencies = [
+ "futures-io",
+ "rustls 0.19.0",
+ "webpki",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6adabac1290109cfa089f79192fb6244ad2c3f1cc2281f3e1dd987592b71feb"
+checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
 
 [[package]]
 name = "futures-task"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92a0843a2ff66823a8f7c77bffe9a09be2b64e533562c412d63075643ec0038"
+checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
 dependencies = [
  "once_cell",
 ]
@@ -1800,9 +1811,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "036a2107cdeb57f6d7322f1b6c363dad67cd63ca3b7d1b925bdf75bd5d96cda9"
+checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
 dependencies = [
  "futures 0.1.30",
  "futures-channel",
@@ -1817,18 +1828,6 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
-]
-
-[[package]]
-name = "futures_codec"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
-dependencies = [
- "bytes 0.5.6",
- "futures 0.3.9",
- "memchr",
- "pin-project 0.4.27",
 ]
 
 [[package]]
@@ -1919,7 +1918,7 @@ checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -2280,7 +2279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16d7c5e361e6b05c882b4847dd98992534cebc6fcde7f4bc98225bcf10fd6d0d"
 dependencies = [
  "async-io",
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-lite",
  "if-addrs",
  "ipnet",
@@ -2324,7 +2323,7 @@ checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -2335,7 +2334,7 @@ checksum = "6f65a8ecf74feeacdab8d38cb129e550ca871cccaa7d1921d8636ecd75534903"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -2378,7 +2377,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa110ec7b8f493f416eed552740d10e7030ad5f63b2308f82c9608ec2df275"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 2.0.2",
 ]
 
@@ -2401,7 +2400,7 @@ checksum = "ddead8880bc50f57fcd3b5869a7f6ff92570bb4e8f6870c22e2483272f2256da"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -2430,6 +2429,15 @@ name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -2520,7 +2528,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -2614,7 +2622,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "bitvec 0.17.4",
  "frame-executive",
@@ -2775,13 +2783,13 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e17c636b5fe5ff900ccc2840b643074bfac321551d821243a781d0d46f06588"
+checksum = "d5133112ce42be9482f6a87be92a605dd6bbc9e93c297aee77d172ff06908f3a"
 dependencies = [
  "atomic",
- "bytes 0.5.6",
- "futures 0.3.9",
+ "bytes 1.0.1",
+ "futures 0.3.12",
  "lazy_static",
  "libp2p-core",
  "libp2p-core-derive",
@@ -2807,16 +2815,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cb706da14c064dce54d8864ade6836b3486b51689300da74eeb7053aa4551e"
+checksum = "dad04d3cef6c1df366a6ab58c9cf8b06497699e335d83ac2174783946ff847d6"
 dependencies = [
  "asn1_der",
  "bs58",
  "ed25519-dalek",
  "either",
  "fnv",
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
  "lazy_static",
  "libsecp256k1",
@@ -2826,7 +2834,7 @@ dependencies = [
  "parity-multiaddr",
  "parking_lot 0.11.1",
  "pin-project 1.0.4",
- "prost",
+ "prost 0.7.0",
  "prost-build",
  "rand 0.7.3",
  "ring",
@@ -2834,7 +2842,7 @@ dependencies = [
  "sha2 0.9.2",
  "smallvec 1.6.1",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "void",
  "zeroize",
 ]
@@ -2846,31 +2854,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4bc40943156e42138d22ed3c57ff0e1a147237742715937622a99b10fbe0156"
 dependencies = [
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "libp2p-dns"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e09bab25af01326b4ed9486d31325911437448edda30bc57681502542d49f20"
+checksum = "5153b6db68fd4baa3b304e377db744dd8fea8ff4e4504509ee636abcde88d3e3"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "libp2p-core",
  "log",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43bc51a9bc3780288c526615ba0f5f8216820ea6dcc02b89e8daee526c5fccb"
+checksum = "b40fb36a059b7a8cce1514bd8b546fa612e006c9937caa7f5950cb20021fe91e"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost",
+ "prost 0.7.0",
  "prost-build",
  "smallvec 1.6.1",
  "wasm-timer",
@@ -2878,40 +2886,40 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe68563ee33f3848293919afd61470ebcdea4e757a36cc2c33a5508abec2216"
+checksum = "456f5de8e283d7800ca848b9b9a4e2a578b790bd8ae582b885e831353cf0e5df"
 dependencies = [
  "arrayvec 0.5.2",
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes 1.0.1",
  "either",
  "fnv",
- "futures 0.3.9",
- "futures_codec",
+ "futures 0.3.12",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost",
+ "prost 0.7.0",
  "prost-build",
  "rand 0.7.3",
  "sha2 0.9.2",
  "smallvec 1.6.1",
- "uint 0.8.5",
- "unsigned-varint",
+ "uint",
+ "unsigned-varint 0.6.0",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9e12688e8f14008c950c1efde587cb44dbf316fa805f419cd4e524991236f5"
+checksum = "b974db63233fc0e199f4ede7794294aae285c96f4b6010f853eac4099ef08590"
 dependencies = [
  "async-io",
  "data-encoding",
  "dns-parser",
- "futures 0.3.9",
+ "futures 0.3.12",
  "if-watch",
  "lazy_static",
  "libp2p-core",
@@ -2925,35 +2933,35 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3200fbe6608e623bd9efa459cc8bafa0e4efbb0a2dfcdd0e1387ff4181264b"
+checksum = "2705dc94b01ab9e3779b42a09bbf3712e637ed213e875c30face247291a85af0"
 dependencies = [
- "bytes 0.5.6",
- "futures 0.3.9",
- "futures_codec",
+ "asynchronous-codec",
+ "bytes 1.0.1",
+ "futures 0.3.12",
  "libp2p-core",
  "log",
  "nohash-hasher",
  "parking_lot 0.11.1",
  "rand 0.7.3",
  "smallvec 1.6.1",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0580e0d18019d254c9c349c03ff7b22e564b6f2ada70c045fc39738e144f2139"
+checksum = "4aca322b52a0c5136142a7c3971446fb1e9964923a526c9cc6ef3b7c94e57778"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "curve25519-dalek 3.0.0",
- "futures 0.3.9",
+ "futures 0.3.12",
  "lazy_static",
  "libp2p-core",
  "log",
- "prost",
+ "prost 0.7.0",
  "prost-build",
  "rand 0.7.3",
  "sha2 0.9.2",
@@ -2965,11 +2973,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b2ec86a18cbf09d7df440e7786a2409640c774e476e9a3b4d031382c3d7588"
+checksum = "6f3813276d0708c8db0f500d8beda1bda9ad955723b9cb272c41f4727256f73c"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -2980,13 +2988,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620e2950decbf77554b5aed3824f7d0e2c04923f28c70f9bff1a402c47ef6b1e"
+checksum = "d37637a4b33b5390322ccc068a33897d0aa541daf4fec99f6a7efbf37295346e"
 dependencies = [
  "async-trait",
- "bytes 0.5.6",
- "futures 0.3.9",
+ "bytes 1.0.1",
+ "futures 0.3.12",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -2994,18 +3002,18 @@ dependencies = [
  "minicbor",
  "rand 0.7.3",
  "smallvec 1.6.1",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf5894ee1ee63a38aa58d58a16e3dcf7ede6b59ea7b22302c00c1a41d7aec41"
+checksum = "22ea8c69839a0e593c8c6a24282cb234d48ac37be4153183f4914e00f5303e75"
 dependencies = [
  "either",
- "futures 0.3.9",
+ "futures 0.3.12",
  "libp2p-core",
  "log",
  "rand 0.7.3",
@@ -3016,15 +3024,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2113a7dab2b502c55fe290910cd7399a2aa04fe70a2f5a415a87a1db600c0e"
+checksum = "3dbd3d7076a478ac5a6aca55e74bdc250ac539b95de09b9d09915e0b8d01a6b2"
 dependencies = [
- "async-std",
- "futures 0.3.9",
+ "async-io",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
- "if-addrs",
+ "if-watch",
  "ipnet",
+ "libc",
  "libp2p-core",
  "log",
  "socket2",
@@ -3032,11 +3041,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-wasm-ext"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cd44ea05a4523f40183f60ab6e6a80e400a5ddfc98b0df1c55edeb85576cd9"
+checksum = "6149c46cb76935c80bc8be6ec6e3ebd5f5e1679765a255fb34331d54610f15dd"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "js-sys",
  "libp2p-core",
  "parity-send-wrapper",
@@ -3046,31 +3055,29 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "270c80528e21089ea25b41dd1ab8fd834bdf093ebee422fed3b68699a857a083"
+checksum = "d3b1c6a3431045da8b925ed83384e4c5163e14b990572307fca9c507435d4d22"
 dependencies = [
- "async-tls",
  "either",
- "futures 0.3.9",
+ "futures 0.3.12",
+ "futures-rustls",
  "libp2p-core",
  "log",
  "quicksink",
- "rustls 0.19.0",
  "rw-stream-sink",
  "soketto",
  "url 2.2.0",
- "webpki",
  "webpki-roots 0.21.0",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36799de9092c35782f080032eddbc8de870f94a0def87cf9f8883efccd5cacf0"
+checksum = "490b8b27fc40fe35212df1b6a3d14bffaa4117cbff956fdc2892168a371102ad"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "libp2p-core",
  "parking_lot 0.11.1",
  "thiserror",
@@ -3161,9 +3168,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
 ]
@@ -3184,9 +3191,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be716eb6878ca2263eb5d00a781aa13264a794f519fe6af4fbb2668b2d5441c0"
+checksum = "3aae342b73d57ad0b8b364bd12584819f2c1fe9114285dfcf8b0722607671635"
 dependencies = [
  "hashbrown",
 ]
@@ -3311,12 +3318,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "metered-channel"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
+dependencies = [
+ "futures 0.3.12",
+ "futures-timer 3.0.2",
+]
+
+[[package]]
 name = "mick-jaeger"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c023c3f16109e7f33aa451f773fd61070e265b4977d0b6e344a51049296dd7df"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "rand 0.7.3",
  "thrift",
 ]
@@ -3338,7 +3354,7 @@ checksum = "2e071b3159835ee91df62dbdbfdd7ec366b7ea77c838f43aff4acda6b61bcfb9"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -3437,7 +3453,7 @@ dependencies = [
  "generic-array 0.14.4",
  "multihash-derive",
  "sha2 0.9.2",
- "unsigned-varint",
+ "unsigned-varint 0.5.1",
 ]
 
 [[package]]
@@ -3450,7 +3466,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
  "synstructure",
 ]
 
@@ -3462,16 +3478,16 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "multistream-select"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda822043bba2d6da31c4e14041f9794f8fb130a5959289038d0b809d8888614"
+checksum = "10ddc0eb0117736f19d556355464fc87efc8ad98b29e3fd84f02531eb6e90840"
 dependencies = [
- "bytes 0.5.6",
- "futures 0.3.9",
+ "bytes 1.0.1",
+ "futures 0.3.12",
  "log",
  "pin-project 1.0.4",
  "smallvec 1.6.1",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
 ]
 
 [[package]]
@@ -3714,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3730,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3745,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3770,7 +3786,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3784,7 +3800,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3798,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3813,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3827,8 +3843,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3842,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3863,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3879,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3898,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3914,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3928,7 +3944,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3943,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3957,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3972,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3987,7 +4003,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4000,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4015,7 +4031,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4030,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4050,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4064,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4084,18 +4100,18 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "pallet-sudo"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4109,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4126,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4140,11 +4156,10 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
- "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "serde",
  "smallvec 1.6.1",
@@ -4157,14 +4172,13 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "serde",
  "sp-api",
  "sp-blockchain",
  "sp-core",
@@ -4175,20 +4189,18 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
- "frame-support",
+ "pallet-transaction-payment",
  "parity-scale-codec",
- "serde",
  "sp-api",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
 name = "pallet-treasury"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4203,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4218,7 +4230,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4245,9 +4257,9 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f51a30667591b14f96068b2d12f1306d07a41ebd98239d194356d4d9707ac16"
+checksum = "8bfda2e46fc5e14122649e2645645a81ee5844e0fb2e727ef560cc71a8b2d801"
 dependencies = [
  "arrayref",
  "bs58",
@@ -4257,15 +4269,15 @@ dependencies = [
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "url 2.2.0",
 ]
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
+checksum = "79602888a81ace83e3d1d4b2873286c1f5f906c84db667594e8db8da3506c383"
 dependencies = [
  "arrayvec 0.5.2",
  "bitvec 0.17.4",
@@ -4283,7 +4295,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -4336,7 +4348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
  "proc-macro2 1.0.24",
- "syn 1.0.58",
+ "syn 1.0.60",
  "synstructure",
 ]
 
@@ -4562,7 +4574,7 @@ checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -4573,7 +4585,7 @@ checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -4620,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.7.30"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -4631,7 +4643,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -4644,10 +4656,10 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "bitvec 0.17.4",
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
  "kvdb",
  "kvdb-rocksdb",
@@ -4666,9 +4678,9 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-proposer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
  "polkadot-node-subsystem",
  "polkadot-overseer",
@@ -4690,7 +4702,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -4706,21 +4718,24 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-jaeger",
  "polkadot-node-primitives",
  "polkadot-primitives",
  "sc-network",
+ "strum 0.20.0",
+ "thiserror",
+ "zstd",
 ]
 
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "parity-scale-codec",
  "polkadot-primitives",
  "polkadot-statement-table",
@@ -4732,12 +4747,12 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "async-std",
  "async-trait",
  "derive_more",
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
  "lazy_static",
  "log",
@@ -4762,11 +4777,12 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "async-trait",
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
+ "metered-channel",
  "parity-scale-codec",
  "pin-project 1.0.4",
  "polkadot-node-jaeger",
@@ -4787,10 +4803,10 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "async-trait",
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
  "oorandom",
  "polkadot-node-primitives",
@@ -4805,10 +4821,10 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "derive_more",
- "futures 0.3.9",
+ "futures 0.3.12",
  "log",
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -4828,7 +4844,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "bitvec 0.17.4",
  "frame-system",
@@ -4855,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "jsonrpc-core",
  "pallet-transaction-payment-rpc",
@@ -4885,7 +4901,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "bitvec 0.17.4",
  "frame-executive",
@@ -4950,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "bitvec 0.17.4",
  "frame-support",
@@ -4986,7 +5002,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "bitvec 0.17.4",
  "derive_more",
@@ -5003,7 +5019,7 @@ dependencies = [
  "pallet-vesting",
  "parity-scale-codec",
  "polkadot-primitives",
- "rand 0.8.1",
+ "rand 0.8.2",
  "rand_chacha 0.3.0",
  "rustc-hex",
  "serde",
@@ -5023,11 +5039,11 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.8.3"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "frame-benchmarking",
  "frame-system-rpc-runtime-api",
- "futures 0.3.9",
+ "futures 0.3.12",
  "hex-literal",
  "kusama-runtime",
  "pallet-babe",
@@ -5055,6 +5071,7 @@ dependencies = [
  "sc-consensus-slots",
  "sc-executor",
  "sc-finality-grandpa",
+ "sc-finality-grandpa-warp-sync",
  "sc-network",
  "sc-service",
  "sc-telemetry",
@@ -5088,7 +5105,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -5149,7 +5166,7 @@ dependencies = [
  "impl-codec",
  "impl-rlp",
  "impl-serde",
- "uint 0.9.0",
+ "uint",
 ]
 
 [[package]]
@@ -5170,7 +5187,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
  "version_check",
 ]
 
@@ -5236,25 +5253,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
  "bytes 0.5.6",
- "prost-derive",
+ "prost-derive 0.6.1",
+]
+
+[[package]]
+name = "prost"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+dependencies = [
+ "bytes 1.0.1",
+ "prost-derive 0.7.0",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "heck",
- "itertools 0.8.2",
+ "itertools 0.9.0",
  "log",
  "multimap",
  "petgraph",
- "prost",
+ "prost 0.7.0",
  "prost-types",
  "tempfile",
- "which",
+ "which 4.0.2",
 ]
 
 [[package]]
@@ -5267,17 +5294,30 @@ dependencies = [
  "itertools 0.8.2",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+dependencies = [
+ "anyhow",
+ "itertools 0.9.0",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
- "bytes 0.5.6",
- "prost",
+ "bytes 1.0.1",
+ "prost 0.7.0",
 ]
 
 [[package]]
@@ -5366,9 +5406,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
@@ -5557,7 +5597,7 @@ checksum = "0c523ccaed8ac4b0288948849a350b37d3035827413c458b6a40ddb614bb4f72"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -5599,9 +5639,9 @@ dependencies = [
 
 [[package]]
 name = "retain_mut"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e005d658ad26eacc2b6c506dfde519f4e277e328d0eb3379ca61647d70a8f531"
+checksum = "53552c6c49e1e13f1a203ef0080ab3bbef0beb570a528993e83df057a9d9bba1"
 
 [[package]]
 name = "ring"
@@ -5673,12 +5713,13 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "frame-executive",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
+ "hex-literal",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
@@ -5811,7 +5852,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "pin-project 0.4.27",
  "static_assertions",
 ]
@@ -5843,17 +5884,17 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "async-trait",
  "derive_more",
  "either",
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
  "parity-scale-codec",
- "prost",
+ "prost 0.7.0",
  "prost-build",
  "rand 0.7.3",
  "sc-client-api",
@@ -5871,9 +5912,9 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5894,7 +5935,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5911,7 +5952,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -5932,22 +5973,22 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "sc-client-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "fnv",
- "futures 0.3.9",
+ "futures 0.3.12",
  "hash-db",
  "kvdb",
  "lazy_static",
@@ -5977,7 +6018,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -6007,7 +6048,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -6018,11 +6059,11 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "fork-tree",
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
  "log",
  "merlin",
@@ -6063,10 +6104,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
- "futures 0.3.9",
+ "futures 0.3.12",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -6087,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -6100,9 +6141,9 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -6126,7 +6167,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "sc-client-api",
@@ -6140,7 +6181,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -6168,7 +6209,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -6184,7 +6225,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6199,13 +6240,14 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "finality-grandpa",
  "fork-tree",
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
+ "linked-hash-map",
  "log",
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -6236,11 +6278,11 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
  "finality-grandpa",
- "futures 0.3.9",
+ "futures 0.3.12",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -6258,12 +6300,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-finality-grandpa-warp-sync"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
+dependencies = [
+ "derive_more",
+ "futures 0.3.12",
+ "log",
+ "num-traits 0.2.14",
+ "parity-scale-codec",
+ "parking_lot 0.11.1",
+ "prost 0.6.1",
+ "sc-client-api",
+ "sc-finality-grandpa",
+ "sc-network",
+ "sc-service",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
 name = "sc-informant"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "ansi_term 0.12.1",
- "futures 0.3.9",
+ "futures 0.3.12",
  "log",
  "parity-util-mem",
  "sc-client-api",
@@ -6278,11 +6340,11 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-util",
  "hex",
  "merlin",
@@ -6298,7 +6360,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -6317,32 +6379,33 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "async-std",
  "async-trait",
+ "asynchronous-codec",
  "bitflags",
  "bs58",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "derive_more",
  "either",
  "erased-serde",
  "fnv",
  "fork-tree",
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
- "futures_codec",
  "hex",
  "ip_network",
  "libp2p",
  "linked-hash-map",
  "linked_hash_set",
  "log",
+ "lru",
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.11.1",
  "pin-project 0.4.27",
- "prost",
+ "prost 0.7.0",
  "prost-build",
  "rand 0.7.3",
  "sc-block-builder",
@@ -6350,8 +6413,6 @@ dependencies = [
  "sc-peerset",
  "serde",
  "serde_json",
- "slog",
- "slog_derive",
  "smallvec 1.6.1",
  "sp-arithmetic",
  "sp-blockchain",
@@ -6361,7 +6422,7 @@ dependencies = [
  "sp-utils",
  "substrate-prometheus-endpoint",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "void",
  "wasm-timer",
  "zeroize",
@@ -6370,26 +6431,27 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
  "lru",
  "sc-network",
  "sp-runtime",
+ "substrate-prometheus-endpoint",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-offchain"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
  "hyper 0.13.9",
  "hyper-rustls",
@@ -6412,9 +6474,9 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "libp2p",
  "log",
  "serde_json",
@@ -6425,7 +6487,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -6434,9 +6496,9 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "hash-db",
  "jsonrpc-core",
  "jsonrpc-pubsub",
@@ -6468,10 +6530,10 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
- "futures 0.3.9",
+ "futures 0.3.12",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -6492,7 +6554,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "futures 0.1.30",
  "jsonrpc-core",
@@ -6510,12 +6572,12 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "directories",
  "exit-future",
  "futures 0.1.30",
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
  "hash-db",
  "jsonrpc-core",
@@ -6544,7 +6606,6 @@ dependencies = [
  "sc-transaction-pool",
  "serde",
  "serde_json",
- "slog",
  "sp-api",
  "sp-application-crypto",
  "sp-block-builder",
@@ -6574,7 +6635,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6589,7 +6650,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -6609,20 +6670,21 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
- "futures 0.3.9",
- "futures-timer 3.0.2",
+ "chrono",
+ "futures 0.3.12",
  "libp2p",
  "log",
  "parking_lot 0.11.1",
  "pin-project 0.4.27",
  "rand 0.7.3",
  "serde",
- "slog",
- "slog-json",
- "slog-scope",
+ "serde_json",
+ "sp-utils",
  "take_mut",
+ "tracing",
+ "tracing-subscriber",
  "void",
  "wasm-timer",
 ]
@@ -6630,9 +6692,10 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "ansi_term 0.12.1",
+ "atty",
  "erased-serde",
  "lazy_static",
  "log",
@@ -6641,23 +6704,37 @@ dependencies = [
  "regex",
  "rustc-hash",
  "sc-telemetry",
+ "sc-tracing-proc-macro",
  "serde",
  "serde_json",
- "slog",
  "sp-tracing",
+ "thiserror",
  "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "sc-tracing-proc-macro"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
- "futures 0.3.9",
+ "futures 0.3.12",
  "linked-hash-map",
  "log",
  "parity-util-mem",
@@ -6676,9 +6753,9 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-diagnose",
  "intervalier",
  "log",
@@ -6827,22 +6904,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "974ef1bd2ad8a507599b336595454081ff68a9599b4890af7643c0c0ed73a62c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "8dee1f300f838c8ac340ecb0112b3ac472464fa67e87292bdb3dfc9c49128e17"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -7003,50 +7080,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
-name = "slog"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
-dependencies = [
- "erased-serde",
-]
-
-[[package]]
-name = "slog-json"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
-dependencies = [
- "chrono",
- "erased-serde",
- "serde",
- "serde_json",
- "slog",
-]
-
-[[package]]
-name = "slog-scope"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
-dependencies = [
- "arc-swap",
- "lazy_static",
- "slog",
-]
-
-[[package]]
-name = "slog_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
- "syn 1.0.58",
-]
-
-[[package]]
 name = "smallvec"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7117,7 +7150,7 @@ dependencies = [
  "base64 0.12.3",
  "bytes 0.5.6",
  "flate2",
- "futures 0.3.9",
+ "futures 0.3.12",
  "httparse",
  "log",
  "rand 0.7.3",
@@ -7127,7 +7160,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "sp-core",
@@ -7139,7 +7172,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -7155,19 +7188,19 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7179,7 +7212,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.14",
@@ -7192,7 +7225,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7204,7 +7237,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7215,7 +7248,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7227,9 +7260,9 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "log",
  "lru",
  "parity-scale-codec",
@@ -7245,7 +7278,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "serde",
  "serde_json",
@@ -7254,9 +7287,9 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -7280,7 +7313,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -7300,7 +7333,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7309,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -7321,14 +7354,14 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "base58",
  "blake2-rfc",
  "byteorder",
  "dyn-clonable",
  "ed25519-dalek",
- "futures 0.3.9",
+ "futures 0.3.12",
  "hash-db",
  "hash256-std-hasher",
  "hex",
@@ -7365,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -7374,17 +7407,17 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7395,7 +7428,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -7412,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -7424,9 +7457,9 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "hash-db",
  "libsecp256k1",
  "log",
@@ -7448,22 +7481,22 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "lazy_static",
  "sp-core",
  "sp-runtime",
- "strum",
+ "strum 0.16.0",
 ]
 
 [[package]]
 name = "sp-keystore"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.9",
+ "futures 0.3.12",
  "merlin",
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -7476,11 +7509,12 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-arithmetic",
+ "sp-core",
  "sp-npos-elections-compact",
  "sp-std",
 ]
@@ -7488,18 +7522,18 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "sp-offchain"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7509,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "backtrace",
 ]
@@ -7517,7 +7551,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "serde",
  "sp-core",
@@ -7526,7 +7560,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7547,7 +7581,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -7564,19 +7598,19 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "sp-serializer"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "serde",
  "serde_json",
@@ -7585,7 +7619,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7598,7 +7632,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7608,7 +7642,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "hash-db",
  "log",
@@ -7630,12 +7664,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7648,7 +7682,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "sp-core",
@@ -7661,7 +7695,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -7675,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7688,10 +7722,10 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "derive_more",
- "futures 0.3.9",
+ "futures 0.3.12",
  "log",
  "parity-scale-codec",
  "serde",
@@ -7704,7 +7738,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7718,9 +7752,9 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "futures-core",
  "futures-timer 3.0.2",
  "lazy_static",
@@ -7730,7 +7764,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7742,7 +7776,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -7861,7 +7895,7 @@ checksum = "c7acd32cba35531345f8a94a038874baf00efd0b701c913f5b00d2870b474b64"
 dependencies = [
  "dotenv",
  "either",
- "futures 0.3.9",
+ "futures 0.3.12",
  "heck",
  "hex",
  "proc-macro2 1.0.24",
@@ -7871,7 +7905,7 @@ dependencies = [
  "sha2 0.9.2",
  "sqlx-core",
  "sqlx-rt",
- "syn 1.0.58",
+ "syn 1.0.60",
  "url 2.2.0",
 ]
 
@@ -7930,7 +7964,7 @@ dependencies = [
  "quote 1.0.7",
  "serde",
  "serde_derive",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -7946,7 +7980,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -8008,7 +8042,16 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6138f8f88a16d90134763314e3fc76fa3ed6a7db4725d6acf9a3ef95a3188d22"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.16.0",
+]
+
+[[package]]
+name = "strum"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+dependencies = [
+ "strum_macros 0.20.1",
 ]
 
 [[package]]
@@ -8020,7 +8063,19 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -8031,7 +8086,7 @@ dependencies = [
  "coil",
  "fdlimit",
  "flume",
- "futures 0.3.9",
+ "futures 0.3.12",
  "hashbrown",
  "hex",
  "itertools 0.10.0",
@@ -8068,7 +8123,7 @@ name = "substrate-archive-backend"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
- "futures 0.3.9",
+ "futures 0.3.12",
  "hash-db",
  "hashbrown",
  "kvdb",
@@ -8134,10 +8189,10 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "frame-system-rpc-runtime-api",
- "futures 0.3.9",
+ "futures 0.3.12",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -8157,7 +8212,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#8b3e4c86bc5a86570a3091e470011604fb46d324"
+source = "git+https://github.com/paritytech/substrate?branch=master#dd173ae41f73671e3d2e63eb57e906550d5247ba"
 dependencies = [
  "async-std",
  "derive_more",
@@ -8209,9 +8264,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.58"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -8226,7 +8281,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
  "unicode-xid 0.2.1",
 ]
 
@@ -8250,7 +8305,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.1",
+ "rand 0.8.2",
  "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -8302,7 +8357,7 @@ checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -8683,7 +8738,7 @@ checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -8801,18 +8856,6 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
-dependencies = [
- "byteorder",
- "crunchy",
- "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
-name = "uint"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
@@ -8895,11 +8938,17 @@ name = "unsigned-varint"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35581ff83d4101e58b582e607120c7f5ffb17e632a980b1f38334d76b36908b2"
 dependencies = [
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes 1.0.1",
  "futures-io",
  "futures-util",
- "futures_codec",
 ]
 
 [[package]]
@@ -9032,7 +9081,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -9066,7 +9115,7 @@ checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9094,7 +9143,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "js-sys",
  "parking_lot 0.11.1",
  "pin-utils",
@@ -9176,7 +9225,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.8.27"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "bitvec 0.17.4",
  "frame-executive",
@@ -9247,6 +9296,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "which"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+dependencies = [
+ "libc",
+ "thiserror",
 ]
 
 [[package]]
@@ -9328,7 +9387,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.8.22"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -9336,7 +9395,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.8.22"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -9352,7 +9411,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.8.22"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2fea426f5317c82fa5431b70482b79c386731af"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c222fd6d8dfed9517387086d5caf4997fb8fddce"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.0",
@@ -9395,7 +9454,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aeb8c4043cac71c3c299dff107171c220d179492350ea198e109a414981b83c"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.12",
  "log",
  "nohash-hasher",
  "parking_lot 0.11.1",
@@ -9420,6 +9479,37 @@ checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.58",
+ "syn 1.0.60",
  "synstructure",
+]
+
+[[package]]
+name = "zstd"
+version = "0.5.4+zstd.1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69996ebdb1ba8b1517f61387a883857818a66c8a295f487b1ffd8fd9d2c82910"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "2.0.6+zstd.1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98aa931fb69ecee256d44589d19754e61851ae4769bf963b385119b1cc37a49e"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.4.18+zstd.1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6e8778706838f43f771d80d37787cb2fe06dafe89dd3aebaf6721b9eaec81"
+dependencies = [
+ "cc",
+ "glob",
+ "itertools 0.9.0",
+ "libc",
 ]

--- a/substrate-archive-backend/src/frontend/client.rs
+++ b/substrate-archive-backend/src/frontend/client.rs
@@ -164,7 +164,6 @@ where
 			params.function,
 			&params.arguments,
 			params.overlayed_changes,
-			params.offchain_changes,
 			Some(params.storage_transaction_cache),
 			params.initialize_block,
 			manager,

--- a/substrate-archive-backend/src/lib.rs
+++ b/substrate-archive-backend/src/lib.rs
@@ -16,6 +16,9 @@
 
 //! Read Only Interface with Substrate Backend (kvdb-rocksdb)
 
+#![forbid(unsafe_code)]
+#![deny(dead_code)]
+
 mod block_exec;
 mod database;
 mod frontend;

--- a/substrate-archive-common/src/lib.rs
+++ b/substrate-archive-common/src/lib.rs
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-archive.  If not, see <http://www.gnu.org/licenses/>.
 
+#![forbid(unsafe_code)]
+#![deny(dead_code)]
+
 mod database;
 mod error;
 pub mod models;

--- a/substrate-archive/src/database/queries.rs
+++ b/substrate-archive/src/database/queries.rs
@@ -131,25 +131,6 @@ pub(crate) async fn get_full_block_by_id(conn: &mut sqlx::PgConnection, id: i32)
 	.map_err(Into::into)
 }
 
-/// Get a block by block number from the relational database
-#[cfg(test)]
-pub(crate) async fn get_full_block_by_num(conn: &mut sqlx::PgConnection, block_num: u32) -> Result<BlockModel> {
-	let safe_block_num = i32::try_from(block_num).unwrap_or(i32::MAX);
-	#[allow(clippy::toplevel_ref_arg)]
-	sqlx::query_as!(
-		BlockModel,
-		"
-        SELECT id, parent_hash, hash, block_num, state_root, extrinsics_root, digest, ext, spec
-        FROM blocks
-        WHERE block_num = $1
-        ",
-		safe_block_num
-	)
-	.fetch_one(conn)
-	.await
-	.map_err(Into::into)
-}
-
 /// Check if the runtime version identified by `spec` exists in the relational database
 pub(crate) async fn check_if_meta_exists(spec: u32, conn: &mut PgConnection) -> Result<bool> {
 	let spec = match i32::try_from(spec) {

--- a/substrate-archive/src/lib.rs
+++ b/substrate-archive/src/lib.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-archive.  If not, see <http://www.gnu.org/licenses/>.
 
-// #![allow(warnings)]
-// #![forbid(unsafe_code)]
+#![forbid(unsafe_code)]
+#![deny(dead_code)]
 
 mod actors;
 pub mod archive;


### PR DESCRIPTION
Updates substrate dependencies
  - checking the older version of substrate with `--tests` wouldn't compile because of something in one of the substrate proc macros, so I updated substrate.

- Adds #[deny(dead_code)] to subcrates
- adds cargo checking for tests