### PR TITLE
chore(release): 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [v0.5.2] - 2021-06-02
 ### Added
-- Tracing Wasm Runtimes `v0.9.0`, `v0.9.1`, `v0.9.2`, `v0.9.3`
+- Test for tracing enabled wasm-blobs `v0.9.0`, `v0.9.1`, `v0.9.2`, `v0.9.3` ([#284](https://github.com/paritytech/substrate-archive/pull/284)) ([cd6a446](https://github.com/paritytech/substrate-archive/commit/cd6a446bc66002d1945cbdf0c1b39957218f90fd))
+- Unit testing CI workflow ([#288](https://github.com/paritytech/substrate-archive/pull/288)) ([482af68](https://github.com/paritytech/substrate-archive/commit/482af68fff515a7e3a34ee0c512d735790193cd6))
 
 ### Changed
-- clarify release checklist
+- Clarify release checklist ([#279](https://github.com/paritytech/substrate-archive/pull/279)) ([9abef6e](https://github.com/paritytech/substrate-archive/commit/9abef6e2bdda4c1492b6e232ec38c8c0d59a3749)) && ([#288](https://github.com/paritytech/substrate-archive/pull/288)) ([482af68](https://github.com/paritytech/substrate-archive/commit/482af68fff515a7e3a34ee0c512d735790193cd6))
+- Update dependencies to match runtime `0.9.3`. 
+- Refactor tracing to work with the latest tracing changes in substrate ([#273](https://github.com/paritytech/substrate-archive/pull/273)) ([b322ded](https://github.com/paritytech/substrate-archive/commit/b322ded5cf683270da6d21478e80c9f4dba706dc))
 
 ### Fixed
 - Re-Compile WASM Runtime v0.8.30 with rust compiler version nightly-02-27-2021 to fix 'Storage Root Mismatch' when syncing.

--- a/bin/polkadot-archive/CHANGELOG.md
+++ b/bin/polkadot-archive/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4]
 ### Changed
 - bump polkadot to `v0.9.3`
 

--- a/bin/polkadot-archive/Cargo.toml
+++ b/bin/polkadot-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polkadot-archive"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Andrew Plaza <aplaza@liquidthink.net>"]
 edition = "2018"
 description = "Indexes the Polkadot, Kusama and Westend Networks"

--- a/substrate-archive-backend/Cargo.toml
+++ b/substrate-archive-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-archive-backend"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/substrate-archive/Cargo.toml
+++ b/substrate-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-archive"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Andrew Plaza <andrew.plaza@parity.io>"]
 edition = "2018"
 


### PR DESCRIPTION
Release for 0.5.2

Updates:

Substrate-archive: `Cargo.toml` version
Substrate-archive-backend: `Cargo.toml` version
Root: changelog
polkadot-archive: changelog, `Cargo.toml` version