### PR TITLE
set default log file name = current time in UTC

### DIFF
--- a/bin/polkadot-archive/archive.toml
+++ b/bin/polkadot-archive/archive.toml
@@ -46,7 +46,7 @@ std = "DEBUG"
 #level = "DEBUG"
 # Optional log file directory path, default: "/<local>/substrate_archive/"
 #dir = "./output/"
-# Optional log file name, default: "archive.log"
+# Optional log file name, default: current time in UTC + ".log"
 #name = "archive.log"
 
 # Advanced options

--- a/substrate-archive/src/logger.rs
+++ b/substrate-archive/src/logger.rs
@@ -55,7 +55,9 @@ fn default_file_log_level() -> log::LevelFilter {
 }
 
 fn default_file_log_name() -> String {
-	"substrate-archive.log".into()
+	let mut file_name = chrono::Utc::now().to_rfc3339();
+	file_name.push_str(".log");
+	file_name
 }
 
 pub fn init(config: LoggerConfig) -> io::Result<()> {


### PR DESCRIPTION
example filename is `2021-06-30T17:08:24.692011+00:00.log`. manually tested. should close #304

Any way to make this a 1-liner? I tried `chrono::Utc::now().to_rfc3339().push_str(".log")` but I forgot `push_str` returns `()` instead of our cool new timestamped log file name.