### PR TITLE
[WIP] docker-compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  # container name is:
+  substrate-archive-pg:
+    image: 'postgres:latest'
+    ports:
+      - 5432:5432 # localhost_port:container_port ; don't change container_port
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: 123 # change me
+      POSTGRES_DB: kusama # default db name


### PR DESCRIPTION
This provides a nice docker-compose to easily spin up a pg database that works with polkadot-archive,sqlx-cli and substrate-archive tests. I have `kusama` as the default db name but this can clearly get changed when it gets merged.

To close #206 this PR still needs: 
- docker build file to containerize polkadot-archive
- add that to the `docker-compose.yaml` file so docker compose can spin up both containers easily