### PR TITLE
fix listener, the bug causing unit tests to fail

### DIFF
--- a/bin/polkadot-archive/Cargo.lock
+++ b/bin/polkadot-archive/Cargo.lock
@@ -5467,7 +5467,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-archive"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6896,27 +6896,6 @@ checksum = "e54369147e3e7796c9b885c7304db87ca3d09a0a98f72843d532868675bbfba8"
 dependencies = [
  "bytes 1.0.1",
  "rustc-hex",
-]
-
-[[package]]
-name = "rmp"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f55e5fa1446c4d5dd1f5daeed2a4fe193071771a2636274d0d7a3b082aa7ad6"
-dependencies = [
- "byteorder",
- "num-traits",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839395ef53057db96b84c9238ab29e1a13f2e5c8ec9f66bef853ab4197303924"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
 ]
 
 [[package]]
@@ -9352,7 +9331,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-archive"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "async-std",
  "async-stream",
@@ -9374,7 +9353,6 @@ dependencies = [
  "num_cpus",
  "parity-scale-codec",
  "parking_lot 0.11.1",
- "rmp-serde",
  "sc-chain-spec",
  "sc-client-api",
  "sc-executor",
@@ -9398,7 +9376,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-archive-backend"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "arc-swap",
  "futures 0.3.15",

--- a/substrate-archive/src/actors.rs
+++ b/substrate-archive/src/actors.rs
@@ -335,7 +335,9 @@ where
 
 impl<B, R, D, C> Drop for SystemInstance<B, R, D, C> {
 	fn drop(&mut self) {
-		task::block_on(async { self.listener.kill().await })
+		if let Err(e) = task::block_on(async { self.listener.kill().await }) {
+			log::error!("{}", e)
+		}
 	}
 }
 

--- a/substrate-archive/src/actors.rs
+++ b/substrate-archive/src/actors.rs
@@ -335,7 +335,7 @@ where
 
 impl<B, R, D, C> Drop for SystemInstance<B, R, D, C> {
 	fn drop(&mut self) {
-		if let Err(e) = task::block_on(async { self.listener.kill().await }) {
+		if let Err(e) = task::block_on(self.listener.kill()) {
 			log::error!("{}", e)
 		}
 	}


### PR DESCRIPTION
Fixes a bug with listener where if the listener is spawned and then immediately issued notifications, the listener might miss the first few messages.

In addition I modified the listener `kill()` function to ensure the task finishes on kill (waits for task to be joined after sending the message to close). 