### PR TITLE
migrate docker-compose.yaml for new version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,7 +46,6 @@ services:
     
 networks:
   default:
-    name: sa-network 
     ipam:
       config:
         - subnet: 172.10.10.0/24


### PR DESCRIPTION
The name of the default network has been deprecated. I got an error by it.

```
ERROR: The Compose file './docker-compose.yaml' is invalid because:
networks.default value Additional properties are not allowed ('name' was unexpected)
```