### PR TITLE
decrease prefetch count to 100

### DIFF
--- a/substrate-archive/src/actors.rs
+++ b/substrate-archive/src/actors.rs
@@ -374,7 +374,7 @@ where
 			.register_job::<crate::tasks::execute_block::Job<Block, Runtime, Client, Db>>()
 			.num_threads(self.config.runtime.block_workers)
 			.queue_name(queue)
-			.prefetch(5000)
+			.prefetch(100)
 			// times out if tasks don't start execution on the threadpool within timeout.
 			.timeout(Duration::from_secs(self.config.control.task_timeout))
 			.build()?;


### PR DESCRIPTION
Fixes #342 

From the rabbitmq documentation: https://blog.rabbitmq.com/posts/2012/05/some-queuing-theory-throughput-latency-and-bandwidth the client do ack after it processed the prefetched buffer, so a too large prefetch count like 5000 would make ack timeout.

Currently we publish 1000 messages to rabbitmq everytime(https://github.com/paritytech/substrate-archive/pull/462/files#diff-c1534283c28a073545083cd49a8459f91e52899eb9289b7098327c814d061dc7R200), the average execution time of `execute_block` is about 2 seconds, if we set prefetch count to 100, every consumer can ack in 200 seconds. I think 100 is a reasonable value, in the future we can adjust it with the `block_worker` config.