### PR TITLE
parallelize extrinsic decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7329,9 +7329,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -7341,14 +7341,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
@@ -10056,6 +10055,7 @@ dependencies = [
  "parking_lot",
  "polkadot-service",
  "pretty_env_logger",
+ "rayon",
  "sa-work-queue",
  "sc-chain-spec",
  "sc-client-api",

--- a/substrate-archive/Cargo.toml
+++ b/substrate-archive/Cargo.toml
@@ -34,6 +34,7 @@ tracing-subscriber = "0.2"
 xtra = { version = "0.5", features = ["with-async_std-1"] }
 async-stream = "0.3"
 semver = "1.0"
+rayon = "1.5.3"
 
 # Parity
 desub = { package = "desub", git = "https://github.com/paritytech/desub", branch = "insipx/modified-frame-metadata", features = ["polkadot-js"] }


### PR DESCRIPTION
👋 first time contributor here, hope my formatting is ok!

When running `polkadot-archive` with wasm execution & tracing off, i noticed that all or most of the work to archive blocks & extrinsics was happening on a single thread. This became the bottleneck for how quickly we can index a Substrate chain, so i've done a very basic parallel version of extrinsic decoding.  

Initial tests have shown a significant speedup when decoding batches of extrinsics (with larger batches parallelizing better), and thus a significant increase in throughput of the archiver. However, this has only been tested on a few machines, and I don't think it's perfect yet - sometimes it pushes %100 cpu use across all cores, sometimes not.

This has been running in production for a few days so i feel fairly confident in it. 
Not sure if we need to add any configuration options for this - currently it hardcodes splitting the work in 16 sub-batches no matter the size of the input batch. Happy to add any of that if so.


This attempts to parallelize into batches, have each batch accumulate its own results, and them flatten those accumulated results.  It may also be viable to completely flatten this & rely on rayon to decide how to parallelize, instead of batching.