### PR TITLE
Pin GHA versions

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust Stable toolchain
         uses: actions-rs/toolchain@v1
@@ -30,7 +30,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Cache Dependencies & Build Outputs
-        uses: actions/cache@v3.0.4
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust Stable Toolchain
         uses: actions-rs/toolchain@v1
@@ -24,7 +24,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache Dependencies & Build Outputs
-        uses: actions/cache@v3.0.4
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/node-template.yml
+++ b/.github/workflows/node-template.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust Stable toolchain
         uses: actions-rs/toolchain@v1
@@ -30,7 +30,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Cache Dependencies & Build Outputs
-        uses: actions/cache@v3.0.4
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/polkadot-archive.yml
+++ b/.github/workflows/polkadot-archive.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust Stable toolchain
         uses: actions-rs/toolchain@v1
@@ -30,7 +30,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Cache Dependencies & Build Outputs
-        uses: actions/cache@v3.0.4
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -45,7 +45,7 @@ jobs:
 
       - name: Get Archive changelog
         id: changelog_reader
-        uses: mindsers/changelog-reader-action@v2
+        uses: mindsers/changelog-reader-action@5bfb30f7871d5c4cde50cd897314f37578043394 # v2.1.1
         with:
           validation_depth: 2
           path: ./CHANGELOG.md
@@ -53,7 +53,7 @@ jobs:
 
       - name: Get Polkadot Archive changelog
         id: changelog_reader_polkadot
-        uses: mindsers/changelog-reader-action@v2
+        uses: mindsers/changelog-reader-action@5bfb30f7871d5c4cde50cd897314f37578043394 # v2.1.1
         with:
           validation_depth: 2
           path: ./bin/polkadot-archive/CHANGELOG.md
@@ -69,7 +69,7 @@ jobs:
             EOF
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # v0.1.14
         with:
           tag_name: ${{ steps.changelog_reader.outputs.version }}
           name: Release ${{ steps.changelog_reader.outputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,10 @@ jobs:
           - 5672:5672
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1.0.7
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
@@ -48,7 +48,7 @@ jobs:
           override: true
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1.0.3
+        uses: actions-rs/cargo@v1
         with:
           command: test
         env:


### PR DESCRIPTION
In order to improve our security posture with GitHub Actions usage. I've made a version pinning ether to commit hash or to specific version.

Related issues and policy:
https://github.com/paritytech/ci_cd/issues/464
https://github.com/paritytech/ci_cd/wiki/Policies-and-regulations:-GitHub-Actions-usage-policies